### PR TITLE
Split triangle meshes per treelet during BVH dump

### DIFF
--- a/src/accelerators/bvh.cpp
+++ b/src/accelerators/bvh.cpp
@@ -1038,7 +1038,6 @@ void BVHAccel::dumpTreelets(uint32_t * labels,
         // Split triangle meshes up. Currently we only split the meshes so that all triangles in the
         // treelet are included.
         // TODO(apoms): Split triangle meshes up based on the footprint of the triangles + their textures
-        uint32_t next_id = treelet_id;
         std::map<TriangleMesh *, std::map<size_t, uint32_t>> triangle_mesh_ids;
         std::map<TriangleMesh *, std::map<size_t, std::shared_ptr<TriangleMesh>>> triangle_to_sub_mesh;
         std::map<TriangleMesh *, std::map<size_t, size_t>> triangle_to_sub_mesh_triangle;
@@ -1047,7 +1046,8 @@ void BVHAccel::dumpTreelets(uint32_t * labels,
           std::vector<size_t> &triangle_nums = kv.second;
 
           /* assign this mesh a unique id */
-          const int tm_id = next_id++;
+          const int tm_id =
+              global::manager.getNextId(SceneManager::Type::TriangleMesh);
           /* generate the sub-mesh */
           std::shared_ptr<TriangleMesh> sub_mesh;
           {
@@ -1117,7 +1117,7 @@ void BVHAccel::dumpTreelets(uint32_t * labels,
               triangle_to_sub_mesh[mesh][triangle_num] = sub_mesh;
           }
 
-          // Write out the sub mesh 
+          // Write out the sub mesh
           auto tm_writer = global::manager.GetWriter(
               SceneManager::Type::TriangleMesh, tm_id);
           tm_writer->write(to_protobuf(*sub_mesh));

--- a/src/cloud/manager.cpp
+++ b/src/cloud/manager.cpp
@@ -33,7 +33,7 @@ unique_ptr<protobuf::RecordWriter> SceneManager::GetWriter(
     return make_unique<protobuf::RecordWriter>(FileDescriptor(CheckSystemCall(
         "openat",
         openat(sceneFD->fd_num(), getFileName(type, id).c_str(),
-               O_WRONLY | O_CREAT | O_TRUNC,
+               O_WRONLY | O_CREAT | O_EXCL,
                S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH))));
 }
 

--- a/src/cloud/manager.h
+++ b/src/cloud/manager.h
@@ -5,12 +5,21 @@
 
 #include "messages/serialization.h"
 #include "util/optional.h"
+#include "util/util.hh"
 
 namespace pbrt {
 
 class SceneManager {
   public:
-    enum class Type { Treelet, TriangleMesh, Lights, Sampler, Camera, Scene };
+    enum class Type {
+        Treelet,
+        TriangleMesh,
+        Lights,
+        Sampler,
+        Camera,
+        Scene,
+        COUNT
+    };
 
     SceneManager() {}
 
@@ -22,9 +31,14 @@ class SceneManager {
     std::unique_ptr<protobuf::RecordWriter> GetWriter(
         const Type type, const uint32_t id = 0) const;
 
+    uint32_t getNextId(const Type type) {
+        return autoIds[to_underlying(type)]++;
+    }
+
   private:
     static std::string getFileName(const Type type, const uint32_t id);
 
+    size_t autoIds[to_underlying(Type::COUNT)] = {0};
     Optional<FileDescriptor> sceneFD{};
 };
 


### PR DESCRIPTION
This PR changes the BVH dumping process. Instead of dumping the triangle meshes wholesale, the change here identifies the subset of triangles in each treelet and dumps separate submeshes for each of these triangle subsets. This may increase the total on disk footprint of the dumped triangle meshes (since shared vertices at the boundaries of these submeshes will be duplicated) but should decrease overall bandwidth as workers only need to load the specific submesh for a treelet, instead of the entire mesh.