### PR TITLE
Assigns treelets and dependent objects to workers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,7 +605,11 @@ TARGET_LINK_LIBRARIES ( pbrt_lambda_master ${ALL_PBRT_LIBS} )
 ADD_EXECUTABLE ( pbrt_lambda_worker src/cloud/lambda-worker.cpp )
 SET_TARGET_PROPERTIES ( pbrt_lambda_worker PROPERTIES OUTPUT_NAME "pbrt-lambda-worker" )
 TARGET_COMPILE_FEATURES ( pbrt_lambda_worker PRIVATE ${PBRT_CXX11_FEATURES} )
-TARGET_LINK_LIBRARIES ( pbrt_lambda_worker ${ALL_PBRT_LIBS} dl z unwind lzma -static -Wl,-allow-multiple-definition -s -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
+set(STRIP_SYMBOLS "")
+IF(CMAKE_BUILD_TYPE MATCHES RELEASE)
+  set(STRIP_SYMBOLS "-s")
+ENDIF()
+TARGET_LINK_LIBRARIES ( pbrt_lambda_worker ${ALL_PBRT_LIBS} dl z unwind lzma -static -Wl,-allow-multiple-definition ${STRIP_SYMBOLS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 
 
 # Unit test

--- a/src/accelerators/bvh.cpp
+++ b/src/accelerators/bvh.cpp
@@ -1147,6 +1147,16 @@ uint32_t BVHAccel::dumpTreelets(uint32_t *labels,
           protobuf::TriangleMesh tm_proto = to_protobuf(*sub_mesh);
           tm_proto.set_material_id(material_id);
           tm_writer->write(tm_proto);
+
+          /* track the dependency of the mesh on the material */
+          global::manager.recordDependency(
+              SceneManager::ObjectTypeID{SceneManager::Type::TriangleMesh, tm_id},
+              SceneManager::ObjectTypeID{SceneManager::Type::Material, material_id});
+
+          /* track the dependency of the treelet on the mesh */
+          global::manager.recordDependency(
+              SceneManager::ObjectTypeID{SceneManager::Type::Treelet, treelet_id},
+              SceneManager::ObjectTypeID{SceneManager::Type::TriangleMesh, tm_id});
         }
 
         auto writer =

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -316,6 +316,17 @@ void LambdaWorker::generateRays(const Bounds2i& bounds) {
     }
 }
 
+void LambdaWorker::getObjects(const protobuf::GetObjects& objects) {
+  std::vector<storage::GetRequest> requests;
+  for (const protobuf::ObjectTypeID& objectTypeID : objects.object_ids()) {
+      SceneManager::ObjectTypeID id = from_protobuf(objectTypeID);
+      std::string filePath = id.to_string();
+      std::cout << filePath << std::endl;;
+      requests.emplace_back(filePath, filePath);
+  }
+  storageBackend->get(requests);
+}
+
 bool LambdaWorker::processMessage(const Message& message) {
     cerr << "[msg:" << Message::OPCODE_NAMES[to_underlying(message.opcode())]
          << "]\n";
@@ -332,15 +343,10 @@ bool LambdaWorker::processMessage(const Message& message) {
         break;
     }
 
-    case OpCode::Get: {
-        string line;
-        istringstream iss{message.payload()};
-        vector<storage::GetRequest> requests;
-        while (getline(iss, line)) {
-            if (line.length()) requests.emplace_back(line, line);
-        }
-
-        storageBackend->get(requests);
+    case OpCode::GetObjects: {
+        protobuf::GetObjects proto;
+        protoutil::from_string(message.payload(), proto);
+        getObjects(proto);
         break;
     }
 

--- a/src/cloud/lambda-worker.h
+++ b/src/cloud/lambda-worker.h
@@ -60,6 +60,7 @@ class LambdaWorker {
     Poller::Action::Result::Type handleNeededTreelets();
 
     void generateRays(const Bounds2i& cropWindow);
+    void getObjects(const protobuf::GetObjects& objects);
 
     Address coordinatorAddr;
     ExecutionLoop loop{};

--- a/src/cloud/manager.h
+++ b/src/cloud/manager.h
@@ -26,8 +26,10 @@ class SceneManager {
         COUNT
     };
 
+    using ObjectID = size_t;
+
     struct Object {
-        size_t id;
+        ObjectID id;
         off_t size;
 
         Object(const size_t id, const off_t size) : id(id), size(size) {}

--- a/src/core/paramset.cpp
+++ b/src/core/paramset.cpp
@@ -722,6 +722,43 @@ void ParamSet::Print(int indent) const {
     printItems("rgb", indent, spectra);
 }
 
+void ParamSet::StartRecordingUsage() const {
+#define MOVE_TEMP(v)                                   \
+    for (size_t i = 0; i < (v).size(); ++i) {          \
+        (v)[i]->lookedUpRecordTemp = (v)[i]->lookedUp; \
+        (v)[i]->lookedUp = false;                      \
+    }
+    MOVE_TEMP(ints);
+    MOVE_TEMP(bools);
+    MOVE_TEMP(floats);
+    MOVE_TEMP(point2fs);
+    MOVE_TEMP(vector2fs);
+    MOVE_TEMP(point3fs);
+    MOVE_TEMP(vector3fs);
+    MOVE_TEMP(normals);
+    MOVE_TEMP(spectra);
+    MOVE_TEMP(strings);
+    MOVE_TEMP(textures);
+}
+
+void ParamSet::StopRecordingUsage() const {
+#define UPDATE_USAGE(v)                                                    \
+    for (size_t i = 0; i < (v).size(); ++i) {                              \
+        (v)[i]->lookedUp = (v)[i]->lookedUpRecordTemp || (v)[i]->lookedUp; \
+    }
+    UPDATE_USAGE(ints);
+    UPDATE_USAGE(bools);
+    UPDATE_USAGE(floats);
+    UPDATE_USAGE(point2fs);
+    UPDATE_USAGE(vector2fs);
+    UPDATE_USAGE(point3fs);
+    UPDATE_USAGE(vector3fs);
+    UPDATE_USAGE(normals);
+    UPDATE_USAGE(spectra);
+    UPDATE_USAGE(strings);
+    UPDATE_USAGE(textures);
+}
+
 // TextureParams Method Definitions
 std::shared_ptr<Texture<Spectrum>> TextureParams::GetSpectrumTexture(
     const std::string &n, const Spectrum &def) const {
@@ -839,6 +876,46 @@ reportUnusedMaterialParams(
                          }) == geom.end())
             Warning("Parameter \"%s\" not used", param->name.c_str());
     }
+}
+
+void TextureParams::StartRecordingUsage() const {
+  geomParams.StartRecordingUsage();
+  materialParams.StartRecordingUsage();
+}
+
+void TextureParams::StopRecordingUsage() const {
+  geomParams.StopRecordingUsage();
+  materialParams.StopRecordingUsage();
+}
+
+std::vector<std::string> TextureParams::GetUsedFloatTextures() const {
+    std::vector<std::string> used;
+#define GET_USED(v)                           \
+    for (size_t i = 0; i < (v).size(); ++i) { \
+        if ((v)[i]->lookedUp) {               \
+            used.push_back((v)[i]->name);     \
+        }                                     \
+    }
+    GET_USED(geomParams.textures);
+    GET_USED(geomParams.floats);
+    GET_USED(materialParams.textures);
+    GET_USED(materialParams.floats);
+    return used;
+}
+
+std::vector<std::string> TextureParams::GetUsedSpectrumTextures() const {
+    std::vector<std::string> used;
+#define GET_USED(v)                           \
+    for (size_t i = 0; i < (v).size(); ++i) { \
+        if ((v)[i]->lookedUp) {               \
+            used.push_back((v)[i]->name);     \
+        }                                     \
+    }
+    GET_USED(geomParams.textures);
+    GET_USED(geomParams.spectra);
+    GET_USED(materialParams.textures);
+    GET_USED(materialParams.spectra);
+    return used;
 }
 
 void TextureParams::ReportUnused() const {

--- a/src/core/paramset.h
+++ b/src/core/paramset.h
@@ -121,6 +121,8 @@ class ParamSet {
     void Clear();
     std::string ToString() const;
     void Print(int indent) const;
+    void StartRecordingUsage() const;
+    void StopRecordingUsage() const;
 
   private:
     friend class TextureParams;
@@ -153,6 +155,7 @@ struct ParamSetItem {
     const std::unique_ptr<T[]> values;
     const int nValues;
     mutable bool lookedUp = false;
+    mutable bool lookedUpRecordTemp = false;
 };
 
 // ParamSetItem Methods
@@ -215,7 +218,12 @@ class TextureParams {
         return geomParams.FindOneSpectrum(n,
                                           materialParams.FindOneSpectrum(n, d));
     }
+    void StartRecordingUsage() const;
+    void StopRecordingUsage() const;
+    std::vector<std::string> GetUsedFloatTextures() const;
+    std::vector<std::string> GetUsedSpectrumTextures() const;
     void ReportUnused() const;
+
     const ParamSet &GetGeomParams() const { return geomParams; }
     const ParamSet &GetMaterialParams() const { return materialParams; }
     const std::map<std::string, std::shared_ptr<Texture<Float>>>

--- a/src/execution/meow/message.h
+++ b/src/execution/meow/message.h
@@ -19,7 +19,7 @@ namespace meow {
       Hey = 0x1,
       Ping,
       Pong,
-      Get,
+      GetObjects,
       GenerateRays,
       GetWorker,
       ConnectTo,

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -216,6 +216,15 @@ message Scene {
 
 // LambdaCommands
 
+message ObjectTypeID {
+    uint32 type = 1;
+    uint64 id = 2;
+};
+
+message GetObjects {
+    repeated ObjectTypeID object_ids = 1;
+}
+
 message GenerateRays {
     Bounds2i crop_window = 1;
 }

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -274,3 +274,14 @@ message SpectrumTexture {
   Matrix tex2world = 2;
   TextureParams texture_params = 3;
 }
+
+// Manifest
+
+message Manifest {
+  message Object {
+    ObjectTypeID id = 1;
+    repeated ObjectTypeID dependencies = 2;
+  };
+  repeated Object objects = 1;
+}
+

--- a/src/messages/utils.cpp
+++ b/src/messages/utils.cpp
@@ -284,6 +284,14 @@ protobuf::TextureParams to_protobuf(const TextureParams& texture_params) {
   return params;
 }
 
+protobuf::ObjectTypeID to_protobuf(
+    const SceneManager::ObjectTypeID& objectTypeID) {
+    protobuf::ObjectTypeID proto;
+    proto.set_type(to_underlying(objectTypeID.type));
+    proto.set_id(objectTypeID.id);
+    return proto;
+}
+
 template <class ValueType, class ProtoItem>
 unique_ptr<ValueType[]> p2v(const ProtoItem& item) {
     auto values = make_unique<ValueType[]>(item.values_size());
@@ -555,6 +563,13 @@ TextureParams from_protobuf(
     geom_params = from_protobuf(texture_params.geom_params());
     material_params = from_protobuf(texture_params.material_params());
     return TextureParams(geom_params, material_params, fTex, sTex);
+}
+
+SceneManager::ObjectTypeID from_protobuf(
+    const protobuf::ObjectTypeID& objectTypeID) {
+    return SceneManager::ObjectTypeID{
+        static_cast<SceneManager::Type>(objectTypeID.type()),
+        objectTypeID.id()};
 }
 
 protobuf::Light light::to_protobuf(const string& name, const ParamSet& params,

--- a/src/messages/utils.h
+++ b/src/messages/utils.h
@@ -3,6 +3,7 @@
 
 #include "cloud/integrator.h"
 #include "cloud/raystate.h"
+#include "cloud/manager.h"
 #include "core/geometry.h"
 #include "core/light.h"
 #include "core/paramset.h"
@@ -49,6 +50,7 @@ protobuf::SampleData to_protobuf(const CloudIntegrator::SampleData& sample);
 protobuf::ParamSet to_protobuf(const ParamSet& paramset);
 protobuf::Scene to_protobuf(const Scene& scene);
 protobuf::TextureParams to_protobuf(const TextureParams& texture_params);
+protobuf::ObjectTypeID to_protobuf(const SceneManager::ObjectTypeID& objectTypeID);
 
 Point2i from_protobuf(const protobuf::Point2i& point);
 Point2f from_protobuf(const protobuf::Point2f& point);
@@ -73,6 +75,7 @@ TextureParams from_protobuf(
     ParamSet& material_params,
     std::map<std::string, std::shared_ptr<Texture<Float>>>& fTex,
     std::map<std::string, std::shared_ptr<Texture<Spectrum>>>& sTex);
+SceneManager::ObjectTypeID from_protobuf(const protobuf::ObjectTypeID& objectTypeID);
 
 namespace light {
 

--- a/src/util/uri.cpp
+++ b/src/util/uri.cpp
@@ -12,7 +12,7 @@ using namespace std;
 ParsedURI::ParsedURI( const std::string & uri )
 {
   const static regex uri_regex {
-    R"RAWSTR((([A-Za-z0-9]+)://)?(([^:\n\r]+):([^@\n\r]+)@)?(([^:/\n\r]+):?(\d*))/?([^?\n\r]+)?\??([^#\n\r]*)?#?([^\n\r]*))RAWSTR" };
+    R"RAWSTR((([A-Za-z0-9]+)://)?(([^:\n\r]+):([^@\n\r]+)@)?(([^?:/\n\r]+):?(\d*))/?([^?\n\r]+)?\??([^#\n\r]*)?#?([^\n\r]*))RAWSTR" };
 
   smatch uri_match_result;
 


### PR DESCRIPTION
This PR adds several things:
- Manifest: objects and their dependencies (e.g. triangle meshes depend on materials) are now tracked in a manifest file that is created during dump.
- Treelet/object assignment: the master now has the ability to assign individual treelets and objects (materials, textures, meshes, etc) which will then be loaded by the workers.