### PR TITLE
Remap texture paths to scene directory and compact triangle meshes into treelets

### DIFF
--- a/src/accelerators/bvh.cpp
+++ b/src/accelerators/bvh.cpp
@@ -1056,6 +1056,12 @@ uint32_t BVHAccel::dumpTreelets(uint32_t *labels,
           triangle_mesh_material_ids[mesh] = material_id;
         }
 
+        auto writer =
+            global::manager.GetWriter(SceneManager::Type::Treelet, treelet_id);
+
+        uint32_t num_triangle_meshes = triangles_in_treelet.size();
+        writer->write(num_triangle_meshes);
+
         /* Split up triangle meshes. Currently we only split the meshes so that
          all triangles in the treelet are included.
          TODO(apoms): Split triangle meshes up based on the footprint of the
@@ -1142,11 +1148,10 @@ uint32_t BVHAccel::dumpTreelets(uint32_t *labels,
           }
 
           /* write out the sub mesh */
-          auto tm_writer = global::manager.GetWriter(
-              SceneManager::Type::TriangleMesh, tm_id);
           protobuf::TriangleMesh tm_proto = to_protobuf(*sub_mesh);
+          tm_proto.set_id(tm_id);
           tm_proto.set_material_id(material_id);
-          tm_writer->write(tm_proto);
+          writer->write(tm_proto);
 
           /* track the dependency of the mesh on the material */
           global::manager.recordDependency(
@@ -1158,9 +1163,6 @@ uint32_t BVHAccel::dumpTreelets(uint32_t *labels,
               SceneManager::ObjectTypeID{SceneManager::Type::Treelet, treelet_id},
               SceneManager::ObjectTypeID{SceneManager::Type::TriangleMesh, tm_id});
         }
-
-        auto writer =
-            global::manager.GetWriter(SceneManager::Type::Treelet, treelet_id);
 
         const uint32_t current_treelet = labels[root_index];
         std::stack<int> q;

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -363,7 +363,13 @@ void LambdaWorker::getObjects(const protobuf::GetObjects& objects) {
     vector<storage::GetRequest> requests;
     for (const protobuf::ObjectTypeID& objectTypeID : objects.object_ids()) {
         SceneManager::ObjectTypeID id = from_protobuf(objectTypeID);
-        if (id.type == SceneManager::Type::Treelet) treeletIds.insert(id.id);
+        if (id.type == SceneManager::Type::TriangleMesh) {
+          /* triangle meshes are packed into treelets, so ignore */
+          continue;
+        }
+        if (id.type == SceneManager::Type::Treelet) {
+          treeletIds.insert(id.id);
+        }
         string filePath = id.to_string();
         requests.emplace_back(filePath, filePath);
     }

--- a/src/cloud/manager.cpp
+++ b/src/cloud/manager.cpp
@@ -120,8 +120,11 @@ SceneManager::listObjects() {
     /* read the list of objects from the manifest file */
     for (auto& kv : dependencies) {
       const ObjectTypeID& id = kv.first;
-      std::string filename = getFileName(id.type, id.id);
-      const size_t size = roost::file_size_at(*sceneFD, filename);
+      size_t size = 0;
+      if (id.type != Type::TriangleMesh) {
+          std::string filename = getFileName(id.type, id.id);
+          size = roost::file_size_at(*sceneFD, filename);
+      }
       result[id.type].push_back(Object(id.id, size));
     }
 

--- a/src/cloud/manager.h
+++ b/src/cloud/manager.h
@@ -70,6 +70,8 @@ class SceneManager {
     std::map<Type, std::vector<Object>> listObjects();
     std::map<ObjectTypeID, std::set<ObjectTypeID>> listObjectDependencies();
 
+  const std::string& getScenePath() { return scenePath; }
+
   private:
     static std::string getFileName(const Type type, const uint32_t id);
     void loadManifest();

--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -1272,6 +1272,9 @@ void pbrtTexture(const std::string &name, const std::string &type,
 
     TextureParams tp(params, params, *graphicsState.floatTextures,
                      *graphicsState.spectrumTextures);
+    if (PbrtOptions.dumpScene) {
+      tp.RemapFilenames(global::manager.getScenePath());
+    }
     if (type == "float") {
         // Create _Float_ texture and store in _floatTextures_
         if (graphicsState.floatTextures->find(name) !=

--- a/src/core/fileutil.cpp
+++ b/src/core/fileutil.cpp
@@ -88,6 +88,11 @@ std::string DirectoryContaining(const std::string &filename) {
     return filename;
 }
 
+std::string BaseFilename(const std::string &filename) {
+    throw new std::logic_error("Not implemented on Windows.");
+    return filename;
+}
+
 #else
 
 bool IsAbsolutePath(const std::string &filename) {
@@ -120,7 +125,33 @@ std::string DirectoryContaining(const std::string &filename) {
     return result;
 }
 
+std::string BaseFilename(const std::string &filename) {
+    char *t = strdup(filename.c_str());
+    std::string result = basename(t);
+    free(t);
+    return result;
+}
+
 #endif
+
+std::string RandomString(std::string::size_type length) {
+    static auto &chrs =
+        "0123456789"
+        "abcdefghijklmnopqrstuvwxyz"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    thread_local static std::mt19937 rg{std::random_device{}()};
+    thread_local static std::uniform_int_distribution<std::string::size_type>
+        pick(0, sizeof(chrs) - 2);
+
+    std::string s;
+
+    s.reserve(length);
+
+    while (length--) s += chrs[pick(rg)];
+
+    return s;
+}
 
 void SetSearchDirectory(const std::string &dirname) {
     searchDirectory = dirname;

--- a/src/core/fileutil.h
+++ b/src/core/fileutil.h
@@ -51,7 +51,9 @@ bool IsAbsolutePath(const std::string &filename);
 std::string AbsolutePath(const std::string &filename);
 std::string ResolveFilename(const std::string &filename);
 std::string DirectoryContaining(const std::string &filename);
+std::string BaseFilename(const std::string &filename);
 void SetSearchDirectory(const std::string &dirname);
+std::string RandomString(std::string::size_type length);
 
 inline bool HasExtension(const std::string &value, const std::string &ending) {
     if (ending.size() > value.size()) return false;

--- a/src/core/paramset.h
+++ b/src/core/paramset.h
@@ -123,6 +123,10 @@ class ParamSet {
     void Print(int indent) const;
     void StartRecordingUsage() const;
     void StopRecordingUsage() const;
+    void RemapFilenames(const std::string &basepath) const;
+    const std::map<std::string, std::string> &GetRemappedFilenames() const {
+        return remappedFilenames;
+    }
 
   private:
     friend class TextureParams;
@@ -142,6 +146,9 @@ class ParamSet {
     std::vector<std::shared_ptr<ParamSetItem<std::string>>> strings;
     std::vector<std::shared_ptr<ParamSetItem<std::string>>> textures;
     static std::map<std::string, Spectrum> cachedSpectra;
+
+    mutable std::string remappingBasePath = "";
+    mutable std::map<std::string, std::string> remappedFilenames;
 };
 
 template <typename T>
@@ -220,6 +227,8 @@ class TextureParams {
     }
     void StartRecordingUsage() const;
     void StopRecordingUsage() const;
+    void RemapFilenames(const std::string &basepath) const;
+    std::map<std::string, std::string> GetRemappedFilenames() const;
     std::vector<std::string> GetUsedFloatTextures() const;
     std::vector<std::string> GetUsedSpectrumTextures() const;
     void ReportUnused() const;

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -77,6 +77,7 @@ message TriangleMesh {
     repeated Vector3f s = 6;  // Vector3f
     repeated Point2f uv = 7;
     int64 material_id = 8;
+    int64 id = 9;
 }
 
 message Triangle {

--- a/src/messages/serialization.h
+++ b/src/messages/serialization.h
@@ -29,6 +29,8 @@ public:
 
     void write(const std::string & string);
 
+    void write(const uint32_t& integer);
+
     void write_empty();
 
 private:
@@ -49,6 +51,11 @@ public:
 
     template<class ProtobufType>
     bool read(ProtobufType * record);
+  
+    bool read(std::string* string);
+
+    bool read(uint32_t* integer);
+
     bool eof() const { return eof_; }
 
 private:


### PR DESCRIPTION
This PR makes two changes:

- Ptex texture paths are now local to the scene directory. This is accomplished by remapping the filenames to paths local to the scene directory and copying the ptex files into that location.
- Triangle meshes are now included in the treelet file. The number of small files that were being created for all the triangle meshes was gigantic (~425k for the small susbset of moana). However, because we split the triangle meshes per treelet, we can compact them into the same file as the treelet and massively reduce the number of files that need to be read. After making this change, the number of files generated is ~1.9k for the same subset of moana.