### PR TITLE
Track more advanced stats and use for assign treelets

### DIFF
--- a/src/cloud/integrator.cpp
+++ b/src/cloud/integrator.cpp
@@ -6,6 +6,7 @@
 #include <iterator>
 
 #include "cloud/stats.h"
+#include "cloud/manager.h"
 #include "core/paramset.h"
 
 using namespace std;
@@ -66,12 +67,12 @@ vector<RayState> CloudIntegrator::Shade(RayState &&rayState,
 
             ++nIntersectionTests;
         } else {
-            global::workerStats.finishedPaths++;
+            global::workerStats.recordFinishedPath();
             ReportValue(pathLength, rayState.bounces);
         }
     } else {
         /* we're done with this path */
-        global::workerStats.finishedPaths++;
+        global::workerStats.recordFinishedPath();
         ReportValue(pathLength, rayState.bounces);
     }
 

--- a/src/cloud/lambda-master.cpp
+++ b/src/cloud/lambda-master.cpp
@@ -380,6 +380,16 @@ bool LambdaMaster::processMessage(const uint64_t workerId,
         workerStats.merge(stats);
         /* merge into local worker stats */
         workers.at(workerId).stats.merge(stats);
+        /* sort treelet load */
+        int treeletID = 0;
+        std::vector<std::tuple<uint64_t, uint64_t>> treeletLoads;
+        for (auto &kv : workerStats.objectStats) {
+            auto &rayStats = kv.second;
+            uint64_t load = rayStats.waitingRays - rayStats.processedRays;
+            treeletLoads.push_back(std::make_tuple(load, kv.first.id));
+        }
+        std::sort(treeletLoads.begin(), treeletLoads.end(),
+                  std::greater<std::tuple<uint64_t, uint64_t>>());
         break;
     }
 

--- a/src/cloud/lambda-master.cpp
+++ b/src/cloud/lambda-master.cpp
@@ -478,7 +478,7 @@ std::string LambdaMaster::getSummary() {
         oss << "Longest worker: " << durations[durations.size() - 1]
             << std::endl;
     }
-    std::cout << oss.str() << std::endl;
+    return oss.str();
 }
 
 void LambdaMaster::loadCamera() {
@@ -688,7 +688,7 @@ int main(int argc, char const *argv[]) {
         } catch (const interrupt_error &e) {
             /* if we Ctrl+C while running the master, print out a summary of the
              * run */
-            master.getSummary();
+            std::cout << master.getSummary() << std::endl;
             return EXIT_FAILURE;
         }
     } catch (const exception &e) {

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -47,10 +47,6 @@ class LambdaMaster {
         size_t size;
         std::set<uint64_t>
             workers; /* the set of workers which have this scene object */
-        float rayRequestsPerSecond{
-            1}; /* the production rate for rays that need this scene object */
-        float raysProcessedPerSecond{
-            1}; /* the processing rate of rays for this scene object */
     };
 
     struct Worker {
@@ -131,6 +127,7 @@ class LambdaMaster {
     std::set<ObjectTypeID> treeletIds;
     std::map<ObjectTypeID, std::set<ObjectTypeID>> requiredDependentObjects;
     std::stack<ObjectTypeID> unassignedTreelets;
+    std::vector<std::tuple<uint64_t, uint64_t>> treeletPriority;
 
     /* Always-on FD */
     FileDescriptor dummyFD{STDOUT_FILENO};

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -35,6 +35,8 @@ class LambdaMaster {
 
     void run();
 
+    std::string getSummary();
+
     static constexpr int TILE_SIZE = 32;
 
   private:
@@ -61,6 +63,7 @@ class LambdaMaster {
         std::set<ObjectTypeID> objects;
         size_t freeSpace{2 * 1000 * 1000 *
                          1000}; /* in bytes (assuming 2 GBs free to start) */
+        WorkerStats stats;
 
         Worker(const WorkerId id, std::shared_ptr<TCPConnection> &&connection)
             : id(id), connection(std::move(connection)) {}

--- a/src/cloud/lambda-worker.h
+++ b/src/cloud/lambda-worker.h
@@ -67,6 +67,8 @@ class LambdaWorker {
 
     void generateRays(const Bounds2i& cropWindow);
     void getObjects(const protobuf::GetObjects& objects);
+    void pushRayQueue(RayState&& state);
+    RayState popRayQueue();
 
     Address coordinatorAddr;
     ExecutionLoop loop{};

--- a/src/cloud/stats.cpp
+++ b/src/cloud/stats.cpp
@@ -4,4 +4,80 @@ namespace pbrt {
 namespace global {
 WorkerStats workerStats;
 }
+
+void RayStats::reset() {
+    finishedPaths = 0;
+    sentRays = 0;
+    receivedRays = 0;
+    for (double& d : traceDurationPercentiles) {
+        d = 0;
+    }
+#ifdef PER_RAY_STATS
+    rayDurations.clear();
+#endif  // PER_RAY_STATS
+}
+
+void RayStats::merge(const RayStats& other) {
+    finishedPaths += other.finishedPaths;
+    sentRays += other.sentRays;
+    receivedRays += other.receivedRays;
+    for (int i = 0; i < NUM_PERCENTILES; ++i) {
+        traceDurationPercentiles[i] += other.traceDurationPercentiles[i];
+    }
+#ifdef PER_RAY_STATS
+    rayDurations.insert(rayDurations.end(), other.rayDurations.begin(),
+                        other.rayDurations.end());
+#endif  // PER_RAY_STATS
+}
+
+#define INCREMENT_FIELD(name__)          \
+    do {                                 \
+        aggregateStats.name__ += 1;    \
+        objectStats[type].name__ += 1; \
+    } while (false)
+
+void WorkerStats::recordFinishedPath() { aggregateStats.finishedPaths += 1; }
+
+void WorkerStats::recordSentRay(const SceneManager::ObjectTypeID& type) {
+    INCREMENT_FIELD(sentRays);
+}
+void WorkerStats::recordReceivedRay(const SceneManager::ObjectTypeID& type) {
+    INCREMENT_FIELD(receivedRays);
+}
+void WorkerStats::recordRayTraversal(const SceneManager::ObjectTypeID& type) {
+    INCREMENT_FIELD(rayTraversals);
+}
+
+#undef INCREMENT_FIELD
+
+void WorkerStats::reset() {
+    aggregateStats.reset();
+    objectStats.clear();
+    timePerAction.clear();
+    totalTime = 0;
+}
+
+void WorkerStats::merge(const WorkerStats& other) {
+    aggregateStats.merge(other.aggregateStats);
+    for (const auto& kv : other.objectStats) {
+        objectStats[kv.first].merge(kv.second);
+    }
+    for (const auto& kv : other.timePerAction) {
+        timePerAction[kv.first] += kv.second;
+    }
+    totalTime += other.totalTime;
+}
+
+WorkerStats::Recorder::~Recorder() {
+    auto end = now();
+    stats.timePerAction[name] +=
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            (end - start)).count();
+}
+
+WorkerStats::Recorder::Recorder(WorkerStats& stats_, const std::string& name_)
+    : stats(stats), name(name_) {
+    start = now();
+}
+
 }  // namespace pbrt

--- a/src/cloud/stats.h
+++ b/src/cloud/stats.h
@@ -2,24 +2,79 @@
 #define PBRT_CLOUD_STATS_H
 
 #include <cstdint>
+#include <chrono>
+#include <ctime>
+#include <cstdio>
+
+#include "cloud/manager.h"
 
 namespace pbrt {
 
-struct WorkerStats {
+/* timing utility functions */
+using timepoint_t = std::chrono::time_point<std::chrono::system_clock>;
+inline timepoint_t now() {
+  return std::chrono::system_clock::now();
+};
+
+#define PER_RAY_STATS
+
+const double RAY_PERCENTILES[] = {0.5, 0.9, 0.99, 0.999};
+constexpr size_t NUM_PERCENTILES = sizeof(RAY_PERCENTILES) / sizeof(double);
+
+struct RayStats {
     uint64_t finishedPaths{0};
     uint64_t sentRays{0};
     uint64_t receivedRays{0};
+    uint64_t rayTraversals{0};
 
-    void reset() {
-        finishedPaths = 0;
-        sentRays = 0;
-        receivedRays = 0;
-    }
+    double traceDurationPercentiles[NUM_PERCENTILES] = {0.0, 0.0, 0.0, 0.0};
+    std::vector<double> rayDurations;
 
-    void merge(const WorkerStats &other) {
-        finishedPaths += other.finishedPaths;
-        sentRays += other.sentRays;
-        receivedRays += other.receivedRays;
+    void reset();
+    void merge(const RayStats& other);
+};
+
+struct WorkerStats {
+    RayStats aggregateStats;
+    std::map<SceneManager::ObjectTypeID, RayStats> objectStats;
+
+    std::map<std::string, double> timePerAction;
+    double totalTime{0};
+
+    timepoint_t start;
+    timepoint_t end;
+
+    uint64_t finishedPaths() const { return aggregateStats.finishedPaths; }
+    uint64_t sentRays() const { return aggregateStats.sentRays; }
+    uint64_t receivedRays() const { return aggregateStats.receivedRays; }
+    uint64_t rayTraversals() const { return aggregateStats.receivedRays; }
+
+    void recordFinishedPath();
+    void recordSentRay(const SceneManager::ObjectTypeID& type);
+    void recordReceivedRay(const SceneManager::ObjectTypeID& type);
+    void recordRayTraversal(const SceneManager::ObjectTypeID& type);
+
+    void reset();
+
+    void merge(const WorkerStats& other);
+
+    /* for recording action intervals */
+    struct Recorder {
+        ~Recorder();
+
+      private:
+        friend WorkerStats;
+
+        Recorder(WorkerStats& stats_, const std::string& name_);
+
+        WorkerStats& stats;
+        std::string name;
+        timepoint_t start;
+    };
+
+    friend Recorder;
+    Recorder recordInterval(const std::string& name) {
+        return Recorder(*this, name);
     }
 };
 

--- a/src/cloud/stats.h
+++ b/src/cloud/stats.h
@@ -22,10 +22,14 @@ const double RAY_PERCENTILES[] = {0.5, 0.9, 0.99, 0.999};
 constexpr size_t NUM_PERCENTILES = sizeof(RAY_PERCENTILES) / sizeof(double);
 
 struct RayStats {
-    uint64_t finishedPaths{0};
+    /* rays sent to this scene object */
     uint64_t sentRays{0};
+    /* rays received for this scene object */
     uint64_t receivedRays{0};
-    uint64_t rayTraversals{0};
+    /* rays waiting to be processed for this scene object */
+    uint64_t waitingRays{0};
+    /* rays processed for this scene object */
+    uint64_t processedRays{0};
 
     double traceDurationPercentiles[NUM_PERCENTILES] = {0.0, 0.0, 0.0, 0.0};
     std::vector<double> rayDurations;
@@ -35,6 +39,7 @@ struct RayStats {
 };
 
 struct WorkerStats {
+    uint64_t _finishedPaths{0};
     RayStats aggregateStats;
     std::map<SceneManager::ObjectTypeID, RayStats> objectStats;
 
@@ -44,15 +49,17 @@ struct WorkerStats {
     timepoint_t start;
     timepoint_t end;
 
-    uint64_t finishedPaths() const { return aggregateStats.finishedPaths; }
+    uint64_t finishedPaths() const { return _finishedPaths; }
     uint64_t sentRays() const { return aggregateStats.sentRays; }
     uint64_t receivedRays() const { return aggregateStats.receivedRays; }
-    uint64_t rayTraversals() const { return aggregateStats.receivedRays; }
+    uint64_t waitingRays() const { return aggregateStats.waitingRays; }
+    uint64_t processedRays() const { return aggregateStats.processedRays; }
 
     void recordFinishedPath();
     void recordSentRay(const SceneManager::ObjectTypeID& type);
     void recordReceivedRay(const SceneManager::ObjectTypeID& type);
-    void recordRayTraversal(const SceneManager::ObjectTypeID& type);
+    void recordWaitingRay(const SceneManager::ObjectTypeID& type);
+    void recordProcessedRay(const SceneManager::ObjectTypeID& type);
 
     void reset();
 

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -266,10 +266,25 @@ message ConnectResponse {
     repeated uint32 treelet_ids = 4;
 }
 
-message WorkerStats {
+message RayStats {
     uint64 finished_paths = 1;
     uint64 sent_rays = 2;
     uint64 received_rays = 3;
+
+    repeated float trace_duration_percentiles = 4;
+    repeated float ray_durations = 5;
+}
+
+message WorkerStats {
+  message ObjectRayStats {
+    ObjectTypeID id = 1;
+    RayStats stats = 2;
+  }
+
+  RayStats aggregate_stats = 1;
+  repeated ObjectRayStats object_stats = 2;
+  map<string, float> time_per_action = 3;
+  float total_time = 4;
 }
 
 // Materials & Textures

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -267,12 +267,13 @@ message ConnectResponse {
 }
 
 message RayStats {
-    uint64 finished_paths = 1;
-    uint64 sent_rays = 2;
-    uint64 received_rays = 3;
+    uint64 sent_rays = 1;
+    uint64 received_rays = 2;
+    uint64 waiting_rays = 3;
+    uint64 processed_rays = 4;
 
-    repeated float trace_duration_percentiles = 4;
-    repeated float ray_durations = 5;
+    repeated float trace_duration_percentiles = 5;
+    repeated float ray_durations = 6;
 }
 
 message WorkerStats {
@@ -281,10 +282,11 @@ message WorkerStats {
     RayStats stats = 2;
   }
 
-  RayStats aggregate_stats = 1;
-  repeated ObjectRayStats object_stats = 2;
-  map<string, float> time_per_action = 3;
-  float total_time = 4;
+  uint64 finished_paths = 1;
+  RayStats aggregate_stats = 2;
+  repeated ObjectRayStats object_stats = 3;
+  map<string, float> time_per_action = 4;
+  float total_time = 5;
 }
 
 // Materials & Textures

--- a/src/messages/utils.cpp
+++ b/src/messages/utils.cpp
@@ -294,9 +294,10 @@ protobuf::ObjectTypeID to_protobuf(
 
 protobuf::RayStats to_protobuf(const RayStats& stats) {
   protobuf::RayStats proto;
-  proto.set_finished_paths(stats.finishedPaths);
   proto.set_sent_rays(stats.sentRays);
   proto.set_received_rays(stats.receivedRays);
+  proto.set_waiting_rays(stats.waitingRays);
+  proto.set_processed_rays(stats.processedRays);
   for (double d : stats.traceDurationPercentiles) {
     proto.add_trace_duration_percentiles(d);
   }
@@ -308,6 +309,7 @@ protobuf::RayStats to_protobuf(const RayStats& stats) {
 
 protobuf::WorkerStats to_protobuf(const WorkerStats& stats) {
     protobuf::WorkerStats proto;
+    proto.set_finished_paths(stats._finishedPaths);
     (*proto.mutable_aggregate_stats()) = to_protobuf(stats.aggregateStats);
     for (const auto& kv : stats.objectStats) {
         protobuf::WorkerStats::ObjectRayStats* ray_stats =
@@ -845,9 +847,10 @@ protobuf::SpectrumTexture spectrum_texture::to_protobuf(
 
 RayStats from_protobuf(const protobuf::RayStats& proto) {
     RayStats stats;
-    stats.finishedPaths = proto.finished_paths();
     stats.sentRays = proto.sent_rays();
     stats.receivedRays = proto.received_rays();
+    stats.waitingRays = proto.waiting_rays();
+    stats.processedRays = proto.processed_rays();
 
     for (int i = 0; i < NUM_PERCENTILES; ++i) {
       double d = proto.trace_duration_percentiles(i);
@@ -862,6 +865,7 @@ RayStats from_protobuf(const protobuf::RayStats& proto) {
 
 WorkerStats from_protobuf(const protobuf::WorkerStats& proto) {
     WorkerStats stats;
+    stats._finishedPaths = proto.finished_paths();
     stats.aggregateStats = from_protobuf(proto.aggregate_stats());
     for (const protobuf::WorkerStats::ObjectRayStats& object_stats :
          proto.object_stats()) {

--- a/src/messages/utils.h
+++ b/src/messages/utils.h
@@ -71,6 +71,7 @@ protobuf::Scene to_protobuf(const Scene& scene);
 protobuf::TextureParams to_protobuf(const TextureParams& texture_params);
 protobuf::ObjectTypeID to_protobuf(
     const SceneManager::ObjectTypeID& objectTypeID);
+protobuf::RayStats to_protobuf(const RayStats& state);
 protobuf::WorkerStats to_protobuf(const WorkerStats& state);
 
 Point2i from_protobuf(const protobuf::Point2i& point);
@@ -98,6 +99,7 @@ TextureParams from_protobuf(
     std::map<std::string, std::shared_ptr<Texture<Spectrum>>>& sTex);
 SceneManager::ObjectTypeID from_protobuf(
     const protobuf::ObjectTypeID& objectTypeID);
+RayStats from_protobuf(const protobuf::RayStats& state);
 WorkerStats from_protobuf(const protobuf::WorkerStats& state);
 
 namespace light {


### PR DESCRIPTION
- *Per scene object stats:* Instead of only tracking aggregate stats about ray arrival rates per worker, this PR now also tracks stats per scene object. This enables the master to determine which scene objects are receiving the most rays.
- *Print summary on Ctrl+C*: The master now prints a summary of the run on Ctrl+C.  This is basic for now but should be extended to show load distribution to workers over the course of the run.