### PR TITLE
Dynamic demand estimation and printing

### DIFF
--- a/src/cloud/estimators.h
+++ b/src/cloud/estimators.h
@@ -1,0 +1,116 @@
+#include <chrono>
+#include <math.h>
+
+/**
+ * This class handles a stream of incoming (value, time) pairs, where the time
+ * values are monotonically increasing, but not uniformly distributed, and
+ * maintains an estimate of the average value over the last `period`.
+ *
+ * An implementation of the (linearly interpolated) exponential moving average
+ * as described in S4.3 of this paper:
+ *   http://www.eckner.com/papers/Algorithms%20for%20Unevenly%20Spaced%20Time%20Series.pdf
+ * That paper cites a high-frequency trading book written by Muller.
+ *
+ * T must support addition and multiplication by doubles
+ */
+template <typename T>
+class ExponentialMovingAverage {
+ public:
+  ExponentialMovingAverage(std::chrono::high_resolution_clock::duration period);
+
+  // Feed this (value, time) pair into the stream.
+  void update(const T& value, std::chrono::high_resolution_clock::time_point time);
+  // Feed this value into the stream with the current time.
+  void updateNow(const T& value);
+
+  // Get the current average estimate
+  const T& getAverage() const { return average; }
+
+ private:
+  // The period over which the moving average is computed.
+  // (e.g. the average of the last `period`)
+  const std::chrono::high_resolution_clock::duration period;
+
+  // Whether the stream has seen no data yet.
+  bool empty;
+  // The last value fed into the stream
+  T lastValue;
+  // The time that the last value was fed into the stream
+  std::chrono::high_resolution_clock::time_point lastTime;
+  // The last value of W2, used when multiple points have the same time.
+  double lastW2;
+
+  // The current estimate of the moving average
+  T average;
+};
+
+template <typename T>
+ExponentialMovingAverage<T>::ExponentialMovingAverage(
+    std::chrono::high_resolution_clock::duration period)
+    : period(period), empty(true) {
+    // lastValue, lastTime, and average will all be ignored since `empty` is
+    // true.
+}
+
+template <typename T>
+void ExponentialMovingAverage<T>::updateNow( const T& value ) {
+  update( value, std::chrono::high_resolution_clock::now() );
+}
+
+template <typename T>
+void ExponentialMovingAverage<T>::update( const T& value, std::chrono::high_resolution_clock::time_point time ) {
+  if ( empty ) {
+    empty = false;
+    average = value;
+    lastW2 = 1.0;
+    lastValue = value;
+  } else {
+    std::chrono::high_resolution_clock::duration deltaT = time - lastTime;
+    if ( deltaT <= std::chrono::nanoseconds{0} ) {
+      average = average + (1.0 - lastW2) * value;
+      lastValue = lastValue + value;
+    } else {
+        double w1 = exp(-double(deltaT.count()) / double(period.count()));
+        double w2 =
+            (1.0 - w1) * double(period.count()) / double(deltaT.count());
+        average = w1 * average + (1.0 - w2) * value + (w2 - w1) * lastValue;
+        lastW2 = w2;
+        lastValue = value;
+    }
+  }
+  lastTime = time;
+}
+
+template <typename T>
+class RateEstimator {
+ public:
+  RateEstimator();
+  void update(const T& value);
+  const T& getRate();
+ private:
+  bool empty;
+  std::chrono::high_resolution_clock::time_point lastTime;
+  ExponentialMovingAverage<T> averager;
+};
+
+template <typename T>
+RateEstimator<T>::RateEstimator() : empty(true), averager(std::chrono::seconds(1)) {}
+
+template <typename T>
+void RateEstimator<T>::update(const T& value) {
+  std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now();
+  if ( empty ) {
+    empty = false;
+  } else {
+    std::chrono::duration<double> period = now - lastTime;
+    T thisRate = value * (1.0 / period.count());
+    averager.update(thisRate, now);
+  }
+  lastTime = now;
+}
+
+template <typename T>
+const T& RateEstimator<T>::getRate() {
+  return averager.getAverage();
+}
+

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "cloud/estimators.h"
 #include "cloud/lambda.h"
 #include "cloud/manager.h"
 #include "cloud/stats.h"
@@ -155,6 +156,8 @@ class LambdaMaster {
 
     /* Worker stats */
     WorkerStats workerStats;
+    RateEstimator<RayStatsD> rateMeter;
+    RateEstimator<RayStatsPerObjectD> rateMeters;
     size_t initializedWorkers{0};
 };
 

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -27,13 +27,18 @@
 
 namespace pbrt {
 
+struct MasterConfiguration {
+  bool treeletStats;
+};
+
 class LambdaMaster {
   public:
     LambdaMaster(const std::string &scenePath, const uint16_t listenPort,
                  const uint32_t numberOfLambdas,
                  const std::string &publicAddress,
                  const std::string &storageBackend,
-                 const std::string &awsRegion);
+                 const std::string &awsRegion,
+                 const MasterConfiguration &config);
 
     void run();
 
@@ -159,6 +164,8 @@ class LambdaMaster {
     RateEstimator<RayStatsD> rateMeter;
     RateEstimator<RayStatsPerObjectD> rateMeters;
     size_t initializedWorkers{0};
+
+    const MasterConfiguration config;
 };
 
 class Schedule {

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 #include <sys/timerfd.h>
 #include <cstdlib>
+#include <getopt.h>
 #include <iterator>
 #include <limits>
 #include <sstream>
@@ -692,26 +693,89 @@ void LambdaWorker::uploadLog() const {
     storageBackend->put(putLogRequest);
 }
 
-void usage(const char* argv0) {
-    cerr << "Usage: " << argv0 << " DESTINATION PORT STORAGE-BACKEND" << endl;
+void usage(const char* argv0, int exitCode) {
+    cerr << "Usage: " << argv0 << " [OPTIONS]" << endl << endl
+         << "Options:" << endl
+         << "  -i --ip IPSTRING        ip of coordinator" << endl
+         << "  -p --port PORT          port of coordinator" << endl
+         << "  -r --aws-region REGION  S3 region to read from" << endl
+         << "  -b --scene-bucket NAME  bucket with scene dump" << endl
+         << "  -h --help               show help information" << endl;
+    exit(exitCode);
 }
 
-int main(int argc, char const* argv[]) {
+int main(int argc, char * argv[]) {
     int exit_status = EXIT_SUCCESS;
+
+    uint16_t listenPort = 50000;
+    string publicIp;
+    string bucketName;
+    string region{"us-west-2"};
+
+    struct option long_options[] = {
+        { "port"     ,          required_argument, nullptr, 'p' },
+        { "ip",                 required_argument, nullptr, 'i' },
+        { "aws-region",         required_argument, nullptr, 'r' },
+        { "scene-bucket",       required_argument, nullptr, 'b' },
+        { "help",               no_argument,       nullptr, 'h' },
+        { nullptr,              0,                 nullptr,  0  },
+    };
+
+    while ( true ) {
+        const int opt = getopt_long( argc, argv, "p:i:r:b:h", long_options, nullptr );
+
+        if ( opt == -1 ) {
+            break;
+        }
+
+        switch ( opt ) {
+          case 'p':
+            {
+              listenPort = stoi( optarg );
+              break;
+            }
+          case 'i':
+            {
+              publicIp = optarg;
+              break;
+            }
+          case 'r':
+            {
+              region = optarg;
+              break;
+            }
+          case 'b':
+            {
+              bucketName = optarg;
+              break;
+            }
+          case 'h':
+            {
+              usage(argv[0], 0);
+              break;
+            }
+          default:
+            {
+              usage(argv[0], 2);
+              break;
+            }
+        }
+    }
+
+    if (listenPort == 0 ||
+        publicIp.empty() ||
+        bucketName.empty() ||
+        region.empty()) {
+      usage(argv[0], 2);
+    }
+
+    ostringstream bucketUri;
+    bucketUri << "s3://" << bucketName << "/?region=" << region;
+
     unique_ptr<LambdaWorker> worker;
 
     try {
-        if (argc <= 0) {
-            abort();
-        }
-
-        if (argc != 4) {
-            usage(argv[0]);
-            return EXIT_FAILURE;
-        }
-
-        const uint16_t coordinatorPort = stoi(argv[2]);
-        worker = make_unique<LambdaWorker>(argv[1], coordinatorPort, argv[3]);
+        worker = make_unique<LambdaWorker>(publicIp, listenPort, bucketUri.str());
         worker->run();
     } catch (const exception& e) {
         LOG(INFO) << argv[0] << ": " << e.what();

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -44,7 +44,7 @@ class ProgramFinished : public exception {};
 
 constexpr chrono::milliseconds PEER_CHECK_INTERVAL{1'000};
 constexpr chrono::milliseconds STATUS_PRINT_INTERVAL{10'000};
-constexpr chrono::milliseconds WORKER_STATS_INTERVAL{2'000};
+constexpr chrono::milliseconds WORKER_STATS_INTERVAL{1'000};
 
 protobuf::FinishedRay createFinishedRay(const size_t sampleId,
                                         const Point2f& pFilm,
@@ -255,6 +255,8 @@ Poller::Action::Result::Type LambdaWorker::handleRayQueue() {
         processedRays.pop_front();
 
         const TreeletId nextTreelet = ray.currentTreelet();
+        global::workerStats.recordDemandedRay(
+            SceneManager::ObjectKey{ObjectType::Treelet, nextTreelet});
 
         if (treeletIds.count(nextTreelet)) {
             pushRayQueue(move(ray));

--- a/src/cloud/stats.h
+++ b/src/cloud/stats.h
@@ -26,6 +26,8 @@ struct RayStats {
     uint64_t waitingRays{0};
     /* rays processed for this scene object */
     uint64_t processedRays{0};
+    /* rays that require (or required) this scence object to render */
+    uint64_t demandedRays{0};
 
     double traceDurationPercentiles[NUM_PERCENTILES] = {0.0, 0.0, 0.0, 0.0};
     std::vector<double> rayDurations;
@@ -69,6 +71,7 @@ struct WorkerStats {
     void recordReceivedRay(const SceneManager::ObjectKey& type);
     void recordWaitingRay(const SceneManager::ObjectKey& type);
     void recordProcessedRay(const SceneManager::ObjectKey& type);
+    void recordDemandedRay(const SceneManager::ObjectKey& type);
 
     void reset();
 
@@ -94,40 +97,60 @@ struct WorkerStats {
     }
 };
 
-/**
- * This class handles a stream of incoming (value, time) pairs, where the time
- * values are monotonically increasing, but not uniformly distributed, and
- * maintains an estimate of the average value over the last `period`.
- *
- * An implementation of the (linearly interpolated) exponential moving average
- * as described in S4.3 of this paper:
- *   http://www.eckner.com/papers/Algorithms%20for%20Unevenly%20Spaced%20Time%20Series.pdf
- * That paper cites a high-frequency trading book written by Muller.
- */
-class ExponentialMovingAverage {
- public:
-  ExponentialMovingAverage(std::chrono::high_resolution_clock::duration period);
+// Ray statistics, but with doubles for numerical stability
+struct RayStatsD {
+    /* rays sent to this scene object */
+    double sentRays{0};
+    /* rays received for this scene object */
+    double receivedRays{0};
+    /* rays waiting to be processed for this scene object */
+    double waitingRays{0};
+    /* rays processed for this scene object */
+    double processedRays{0};
+    /* rays that require (or required) this scence object to render */
+    double demandedRays{0};
 
-  // Feed this (value, time) pair into the stream.
-  double update(double value, std::chrono::high_resolution_clock::time_point time);
-  // Feed this value into the stream with the current time.
-  double updateNow(double value);
+    void reset();
 
- private:
-  // The period over which the moving average is computed.
-  // (e.g. the average of the last `period`)
-  const std::chrono::high_resolution_clock::duration period;
+    RayStatsD()
+        : sentRays(0),
+          receivedRays(0),
+          waitingRays(0),
+          processedRays(0),
+          demandedRays(0) {}
 
-  // Whether the stream has seen no data yet.
-  bool empty;
-  // The last value fed into the stream
-  double lastValue;
-  // The time that the last value was fed into the stream
-  std::chrono::high_resolution_clock::time_point lastTime;
-
-  // The current estimate of the moving average
-  double average;
+    RayStatsD(double sentRays, double receivedRays, double waitingRays,
+              double processedRays, double demandedRays)
+        : sentRays(sentRays),
+          receivedRays(receivedRays),
+          waitingRays(waitingRays),
+          processedRays(processedRays),
+          demandedRays(demandedRays) {}
+    RayStatsD(const RayStats& other)
+        : sentRays(other.sentRays),
+          receivedRays(other.receivedRays),
+          waitingRays(other.waitingRays),
+          processedRays(other.processedRays),
+          demandedRays(other.demandedRays) {}
 };
+
+RayStatsD operator+(const RayStatsD& a, const RayStatsD& b);
+
+RayStatsD operator*(const RayStatsD& a, double scalar);
+
+RayStatsD operator*(double scalar, const RayStatsD& a);
+
+struct RayStatsPerObjectD {
+  std::map<SceneManager::ObjectKey, RayStatsD> stats;
+  RayStatsPerObjectD();
+  RayStatsPerObjectD(const WorkerStats& full);
+};
+
+RayStatsPerObjectD operator+(const RayStatsPerObjectD& a, const RayStatsPerObjectD& b);
+
+RayStatsPerObjectD operator*(const RayStatsPerObjectD& a, double scalar);
+
+RayStatsPerObjectD operator*(double scalar, const RayStatsPerObjectD& a);
 
 
 namespace global {

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -271,9 +271,10 @@ message RayStats {
     uint64 received_rays = 2;
     uint64 waiting_rays = 3;
     uint64 processed_rays = 4;
+    uint64 demanded_rays = 5;
 
-    repeated float trace_duration_percentiles = 5;
-    repeated float ray_durations = 6;
+    repeated float trace_duration_percentiles = 6;
+    repeated float ray_durations = 7;
 }
 
 message QueueStats {

--- a/src/messages/utils.cpp
+++ b/src/messages/utils.cpp
@@ -300,6 +300,7 @@ protobuf::RayStats to_protobuf(const RayStats& stats) {
   proto.set_received_rays(stats.receivedRays);
   proto.set_waiting_rays(stats.waitingRays);
   proto.set_processed_rays(stats.processedRays);
+  proto.set_demanded_rays(stats.demandedRays);
   for (double d : stats.traceDurationPercentiles) {
     proto.add_trace_duration_percentiles(d);
   }
@@ -872,6 +873,7 @@ RayStats from_protobuf(const protobuf::RayStats& proto) {
     stats.receivedRays = proto.received_rays();
     stats.waitingRays = proto.waiting_rays();
     stats.processedRays = proto.processed_rays();
+    stats.demandedRays = proto.demanded_rays();
 
     for (int i = 0; i < NUM_PERCENTILES; ++i) {
       double d = proto.trace_duration_percentiles(i);


### PR DESCRIPTION
Dynamically estimates the ray demand rate (rays/s) for each treelet, and
in total.

Also, a rate estimator for any type implementation addition and scaling.

Note: this does spam the output. I should put it behind a flag sometime.