### PR TITLE
Stabilize estimatation & aggregation techniques

### DIFF
--- a/src/cloud/estimators.cpp
+++ b/src/cloud/estimators.cpp
@@ -1,0 +1,16 @@
+#include "cloud/estimators.h"
+
+#include <algorithm>
+#include <numeric>
+
+using namespace std;
+
+pair<double, double> meanAndStandardDev(const vector<double>& xs) {
+    // There are various stream algorithms, but I think that they're less
+    // numerically stable than this.
+    double mean = std::accumulate(xs.begin(), xs.end(), 0.0) / xs.size();
+    double sumDeviationsSquared = std::accumulate(
+        xs.begin(), xs.end(), 0.0,
+        [mean](double acc, double x) { return acc + (mean - x) * (mean - x); });
+    return std::make_pair(mean, sqrt(sumDeviationsSquared / xs.size()));
+}

--- a/src/cloud/estimators.h
+++ b/src/cloud/estimators.h
@@ -3,6 +3,8 @@
 
 #include <math.h>
 #include <chrono>
+#include <vector>
+#include <utility>
 
 /**
  * This class maintains a moving sum of stream of values.
@@ -91,5 +93,8 @@ template <typename T>
 const T& RateEstimator<T>::getRate() const {
     return sum.getSum();
 }
+
+// Computes the mean and standard deviation
+std::pair<double, double> meanAndStandardDev(const std::vector<double> & xs);
 
 #endif  // PBRT_CLOUD_ESTIMATORS_H

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -170,8 +170,9 @@ class LambdaMaster {
     std::map<WorkerId, std::vector<TreeletId>> staticAssignments;
 
     const MasterConfiguration config;
-    // For estimating the cpu time (in millis) per second wall-clock
-    std::map<WorkerId, RateEstimator<double>> cpuTimeMillisTrackers;
+    // For estimating the cpu utilization of workers. A number that is likely
+    // between 0 and 1.
+    std::map<WorkerId, RateEstimator<double>> cpuUtilizationTracker;
     // For estimating the rays traced per second
     std::map<WorkerId, RateEstimator<double>> processedRayTrackers;
 };

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -159,8 +159,7 @@ class LambdaMaster {
 
     /* Worker stats */
     WorkerStats workerStats;
-    RateEstimator<RayStatsD> rateMeter;
-    RateEstimator<RayStatsPerObjectD> rateMeters;
+    DemandTracker demandTracker;
     size_t initializedWorkers{0};
     size_t diagnosticsReceived{0};
 

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -29,6 +29,7 @@ namespace pbrt {
 
 struct MasterConfiguration {
   bool treeletStats;
+  bool workerStats;
 };
 
 class LambdaMaster {
@@ -169,6 +170,10 @@ class LambdaMaster {
     std::map<WorkerId, std::vector<TreeletId>> staticAssignments;
 
     const MasterConfiguration config;
+    // For estimating the cpu time (in millis) per second wall-clock
+    std::map<WorkerId, RateEstimator<double>> cpuTimeMillisTrackers;
+    // For estimating the rays traced per second
+    std::map<WorkerId, RateEstimator<double>> processedRayTrackers;
 };
 
 class Schedule {

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -3,6 +3,7 @@
 #include <getopt.h>
 #include <glog/logging.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 #include <sys/timerfd.h>
 #include <cstdlib>
 #include <iterator>
@@ -185,6 +186,12 @@ LambdaWorker::LambdaWorker(const string& coordinatorIP,
                 (this->coordinatorConnection->bytes_received +
                  this->udpConnection->bytes_received) -
                 global::workerStats.bytesReceived;
+
+            rusage usage;
+            CheckSystemCall("getrusage", ::getrusage(RUSAGE_SELF, &usage));
+            global::workerStats.cpuTime = std::chrono::milliseconds(
+                1000 * (usage.ru_stime.tv_sec + usage.ru_utime.tv_sec) +
+                (usage.ru_stime.tv_usec + usage.ru_utime.tv_usec) / 1000);
 
             qStats.outstandingUdp = this->udpConnection->queue_size();
 

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -46,7 +46,7 @@ class ProgramFinished : public exception {};
 
 constexpr chrono::milliseconds PEER_CHECK_INTERVAL{1'000};
 constexpr chrono::milliseconds STATUS_PRINT_INTERVAL{10'000};
-constexpr chrono::milliseconds WORKER_STATS_INTERVAL{2'000};
+constexpr chrono::milliseconds WORKER_STATS_INTERVAL{500};
 constexpr chrono::milliseconds RECORD_METRICS_INTERVAL{1'000};
 
 protobuf::FinishedRay createFinishedRay(const size_t sampleId,

--- a/src/cloud/stats.cpp
+++ b/src/cloud/stats.cpp
@@ -84,6 +84,7 @@ void WorkerStats::reset() {
     _finishedPaths = 0;
     aggregateStats.reset();
     objectStats.clear();
+    cpuTime = std::chrono::milliseconds(0);
 }
 
 void WorkerStats::resetDiagnostics() {
@@ -103,6 +104,7 @@ void WorkerStats::merge(const WorkerStats& other) {
     for (const auto& kv : other.objectStats) {
         objectStats[kv.first].merge(kv.second);
     }
+    cpuTime = other.cpuTime;
     for (const auto& kv : other.timePerAction) {
         timePerAction[kv.first] += kv.second;
     }

--- a/src/cloud/stats.h
+++ b/src/cloud/stats.h
@@ -57,6 +57,7 @@ struct WorkerStats {
     RayStats aggregateStats;
     QueueStats queueStats;
     std::map<SceneManager::ObjectKey, RayStats> objectStats;
+    std::chrono::milliseconds cpuTime{0};
 
     /* diagnostic stats */
     std::map<std::string, double> timePerAction;

--- a/src/messages/pbrt.proto
+++ b/src/messages/pbrt.proto
@@ -317,9 +317,10 @@ message WorkerStats {
   RayStats aggregate_stats = 2;
   QueueStats queue_stats = 3;
   repeated ObjectRayStats object_stats = 4;
-  map<string, float> time_per_action = 5;
-  repeated ActionIntervals intervals_per_action = 6;
-  repeated Metrics metrics_over_time = 7;
+  uint64 cpu_millis = 5;
+  map<string, float> time_per_action = 6;
+  repeated ActionIntervals intervals_per_action = 7;
+  repeated Metrics metrics_over_time = 8;
 }
 
 // Materials & Textures

--- a/src/messages/utils.cpp
+++ b/src/messages/utils.cpp
@@ -329,6 +329,7 @@ protobuf::QueueStats to_protobuf(const QueueStats& stats) {
 protobuf::WorkerStats to_protobuf(const WorkerStats& stats) {
     protobuf::WorkerStats proto;
     proto.set_finished_paths(stats._finishedPaths);
+    proto.set_cpu_millis(stats.cpuTime.count());
     (*proto.mutable_aggregate_stats()) = to_protobuf(stats.aggregateStats);
     (*proto.mutable_queue_stats()) = to_protobuf(stats.queueStats);
 
@@ -344,6 +345,7 @@ protobuf::WorkerStats to_protobuf(const WorkerStats& stats) {
 protobuf::WorkerStats to_protobuf_diagnostics(const WorkerStats& stats) {
     protobuf::WorkerStats proto;
     proto.set_finished_paths(stats._finishedPaths);
+    proto.set_cpu_millis(stats.cpuTime.count());
     (*proto.mutable_aggregate_stats()) = to_protobuf(stats.aggregateStats);
     (*proto.mutable_queue_stats()) = to_protobuf(stats.queueStats);
     for (const auto& kv : stats.objectStats) {
@@ -942,6 +944,7 @@ WorkerStats from_protobuf(const protobuf::WorkerStats& proto) {
         auto id = from_protobuf(object_stats.id());
         stats.objectStats[id] = from_protobuf(object_stats.stats());
     }
+    stats.cpuTime = std::chrono::milliseconds(proto.cpu_millis());
 
     for (const auto& kv : proto.time_per_action()) {
         stats.timePerAction[kv.first] = kv.second;


### PR DESCRIPTION
Changes:
* Infrastructure for moving sums instead of moving averages
* Store ray demand per worker, treelet, and (worker, treelet)
* Store total ray demand

Details:

I found a simpler, more numerically stable, and more correct method of
doing rate estimation.
* Simpler, because I deleted more code than I added.
* More numerically stable because there less division by small values.
* More correct because:
   * We no longer assume the clock is monotonic
   * We're able to produce rate estimates after the first data point
   * We don't spit out weird NaNs and INFs

The core of the technique is to use a rolling sum instead of a rolling
average. Yup. It's that simple.

I also found a simpler way to aggregate rates across workers/treelets.