### PR TITLE
lambda-worker.cpp: Reduce string allocations for sending RayPackets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,15 @@ ENDIF()
 
 TARGET_LINK_LIBRARIES ( pbrt_lambda_worker ${ALL_PBRT_LIBS} dl z unwind lzma -static -Wl,-allow-multiple-definition ${STRIP_SYMBOLS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
 
+
+# pbrt-treelet-info
+ADD_EXECUTABLE ( pbrt_treelet_info src/cloud/treelet-info.cpp )
+ADD_SANITIZERS ( pbrt_treelet_info )
+
+SET_TARGET_PROPERTIES ( pbrt_treelet_info PROPERTIES OUTPUT_NAME "pbrt-treelet-info" )
+TARGET_COMPILE_FEATURES ( pbrt_treelet_info PRIVATE ${PBRT_CXX11_FEATURES} )
+TARGET_LINK_LIBRARIES ( pbrt_treelet_info ${ALL_PBRT_LIBS} )
+
 # pbrt-lambda-master
 ADD_EXECUTABLE ( pbrt_lambda_aggregate src/cloud/lambda-aggregate.cpp )
 ADD_SANITIZERS ( pbrt_lambda_aggregate )

--- a/src/cloud/aggregate.cpp
+++ b/src/cloud/aggregate.cpp
@@ -57,13 +57,14 @@ int main(int argc, char const *argv[]) {
         for (string line; getline(cin, line);) {
             protobuf::RecordReader finishedReader{line};
 
-            while(!finishedReader.eof()) {
+            while (!finishedReader.eof()) {
                 ++finishedRayCount;
 
                 string rayStr;
                 finishedReader.read(&rayStr);
-                auto rayStatePtr = RayState::deserialize(rayStr);
-                auto & rayState = *rayStatePtr;
+                RayStatePtr rayStatePtr = make_unique<RayState>();
+                auto &rayState = *rayStatePtr;
+                rayState.Deserialize(rayStr.data(), rayStr.length());
 
                 Spectrum L{rayState.Ld * rayState.beta};
 

--- a/src/cloud/bvh.cpp
+++ b/src/cloud/bvh.cpp
@@ -55,6 +55,8 @@ void CloudBVH::loadTreelet(const uint32_t root_id) const {
         return; /* this tree is already loaded */
     }
 
+    TreeletInfo &info = treelet_info_[root_id];
+
     vector<TreeletNode> nodes;
     auto reader = global::manager.GetReader(ObjectType::Treelet, root_id);
 
@@ -100,11 +102,15 @@ void CloudBVH::loadTreelet(const uint32_t root_id) const {
         if (proto_node.left_ref()) {
             node.has[LEFT] = false;
             node.child[LEFT] = proto_node.left_ref();
+
+            info.children.insert(node.child[LEFT]);
         }
 
         if (proto_node.right_ref()) {
             node.has[RIGHT] = false;
             node.child[RIGHT] = proto_node.right_ref();
+
+            info.children.insert(node.child[RIGHT]);
         }
 
         if (proto_node.transformed_primitives_size()) {
@@ -139,6 +145,8 @@ void CloudBVH::loadTreelet(const uint32_t root_id) const {
                     move(make_unique<TransformedPrimitive>(
                         bvh_instances_[proto_tp.root_ref()],
                         primitive_to_world)));
+
+                info.instances.insert(proto_tp.root_ref());
             }
         } else if (proto_node.triangles_size()) {
             node.leaf = true;

--- a/src/cloud/bvh.h
+++ b/src/cloud/bvh.h
@@ -18,6 +18,11 @@ struct TreeletNode;
 
 class CloudBVH : public Aggregate {
   public:
+    struct TreeletInfo {
+        std::set<uint32_t> children{};
+        std::set<uint32_t> instances{};
+    };
+
     CloudBVH(const uint32_t bvh_root = 0);
     ~CloudBVH() {}
 
@@ -30,6 +35,11 @@ class CloudBVH : public Aggregate {
 
     void Trace(RayState &rayState);
     bool Intersect(RayState &rayState, SurfaceInteraction *isect) const;
+
+    const TreeletInfo &GetInfo(const uint32_t treelet_id) {
+        loadTreelet(treelet_id);
+        return treelet_info_.at(treelet_id);
+    }
 
   private:
     enum Child { LEFT = 0, RIGHT = 1 };
@@ -68,6 +78,8 @@ class CloudBVH : public Aggregate {
     mutable std::map<uint32_t, std::shared_ptr<Material>> materials_;
 
     mutable std::shared_ptr<Material> default_material;
+
+    mutable std::map<uint32_t, TreeletInfo> treelet_info_;
 
     void loadTreelet(const uint32_t root_id) const;
     void clear() const;

--- a/src/cloud/do.cpp
+++ b/src/cloud/do.cpp
@@ -76,7 +76,9 @@ int main(int argc, char const *argv[]) {
             while (!reader.eof()) {
                 string rayStr;
                 if (reader.read(&rayStr)) {
-                    rayStates.push_back(RayState::deserialize(rayStr));
+                    auto rayStatePtr = make_unique<RayState>();
+                    rayStatePtr->Deserialize(rayStr.data(), rayStr.length());
+                    rayStates.push_back(move(rayStatePtr));
                 }
             }
         }
@@ -125,7 +127,8 @@ int main(int argc, char const *argv[]) {
         {
             protobuf::RecordWriter writer{outputPath};
             for (auto &rayState : outputRays) {
-                writer.write(RayState::serialize(rayState));
+                const auto len = rayState->Serialize();
+                writer.write(rayState->serialized, len);
             }
         }
 
@@ -133,7 +136,8 @@ int main(int argc, char const *argv[]) {
         {
             protobuf::RecordWriter writer{finishedPath};
             for (auto &finished : finishedRays) {
-                writer.write(RayState::serialize(finished));
+                const auto len = finished->Serialize();
+                writer.write(finished->serialized, len);
             }
         }
 

--- a/src/cloud/genrays.cpp
+++ b/src/cloud/genrays.cpp
@@ -84,7 +84,8 @@ int main(int argc, char const *argv[]) {
                 state.ray.ScaleDifferentials(rayScale);
                 state.StartTrace();
 
-                rayWriter.write(RayState::serialize(statePtr));
+                const auto len = statePtr->Serialize();
+                rayWriter.write(statePtr->serialized, len);
                 sampleWriter.write(to_protobuf(sampleData));
             } while (sampler->StartNextSample());
         }

--- a/src/cloud/lambda-master.h
+++ b/src/cloud/lambda-master.h
@@ -35,16 +35,15 @@ struct Assignment {
     // clang-format off
     static constexpr int All        = (1 << 0);
     static constexpr int Static     = (1 << 1);
-    static constexpr int StaticZero = (1 << 2);
-    static constexpr int Uniform    = (1 << 3);
+    static constexpr int Uniform    = (1 << 2);
     // clang-format on
 };
 
 enum class FinishedRayAction { Discard, SendBack, Upload };
 
 enum class Task {
-  RayTracing,
-  NetworkTest,
+    RayTracing,
+    NetworkTest,
 };
 
 struct MasterConfiguration {
@@ -202,7 +201,9 @@ class LambdaMaster {
     size_t diagnosticsReceived{0};
 
     /* Static Assignments */
-    void loadStaticAssignment(const uint32_t numWorkers, const bool zeroOnAll);
+    void loadStaticAssignment(const uint32_t assignmentId,
+                              const uint32_t numWorkers);
+
     std::map<WorkerId, std::vector<TreeletId>> staticAssignments;
 
     const MasterConfiguration config;

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -773,8 +773,8 @@ ResultType LambdaWorker::handleUdpSend() {
             outQueueSize--;
         }
 
-        if (queue.size() == 0) {
-            outQueue.erase(treeletId);
+        if (queue.empty()) {
+            outQueue.erase(kvIt);
         }
 
         /* (4) fix the header */
@@ -1181,16 +1181,16 @@ bool LambdaWorker::processMessage(const Message& message) {
 
     case OpCode::SendRays: {
         const char* data = message.payload().data();
+        const uint32_t dataLen = message.payload().length();
         uint32_t offset = 0;
-        uint32_t length = message.payload().length();
 
-        while (offset < length) {
-            length = *reinterpret_cast<const uint32_t*>(data + offset);
+        while (offset < dataLen) {
+            const auto len = *reinterpret_cast<const uint32_t*>(data + offset);
             offset += 4;
 
             RayStatePtr ray = make_unique<RayState>();
-            ray->Deserialize(data + offset, length);
-            offset += length;
+            ray->Deserialize(data + offset, len);
+            offset += len;
 
             ray->hop++;
             workerStats.recordReceivedRay(*ray);

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -1063,6 +1063,7 @@ void LambdaWorker::getObjects(const protobuf::GetObjects& objects) {
         const string filePath = id.to_string();
         requests.emplace_back(filePath, filePath);
     }
+
     storageBackend->get(requests);
 }
 

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -477,6 +477,7 @@ ResultType LambdaWorker::handleRayQueue() {
             ray->Serialize();
 
             if (treeletToWorker.count(nextTreelet)) {
+                logRayAction(*ray, RayAction::Queued);
                 workerStats.recordSendingRay(*ray);
                 outQueue[nextTreelet].push_back(move(ray));
                 outQueueSize++;
@@ -995,10 +996,12 @@ void LambdaWorker::generateRays(const Bounds2i& bounds) {
                 statePtr->Serialize();
 
                 if (treeletToWorker.count(nextTreelet)) {
+                    logRayAction(state, RayAction::Queued);
                     workerStats.recordSendingRay(state);
                     outQueue[nextTreelet].push_back(move(statePtr));
                     outQueueSize++;
                 } else {
+                    logRayAction(state, RayAction::Pending);
                     workerStats.recordPendingRay(state);
                     neededTreelets.insert(nextTreelet);
                     pendingQueue[nextTreelet].push_back(move(statePtr));

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -118,7 +118,7 @@ LambdaWorker::LambdaWorker(const string& coordinatorIP,
         bind(&LambdaWorker::handleRayAcknowledgements, this),
         [this]() {
             return !toBeAcked.empty() ||
-                   (!receivedAcks.empty() && !outstandingRayPackets.empty() &&
+                   (!outstandingRayPackets.empty() &&
                     outstandingRayPackets.front().first <= packet_clock::now());
         },
         []() { throw runtime_error("acks failed"); }));
@@ -679,7 +679,7 @@ ResultType LambdaWorker::handleRayAcknowledgements() {
     // retransmit outstanding packets
     const auto now = packet_clock::now();
 
-    while (!receivedAcks.empty() && !outstandingRayPackets.empty() &&
+    while (!outstandingRayPackets.empty() &&
            outstandingRayPackets.front().first <= now) {
         auto& packet = outstandingRayPackets.front().second;
         auto& thisReceivedAcks = receivedAcks[packet.destination];

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -756,9 +756,13 @@ ResultType LambdaWorker::handleUdpSend() {
 
         packet.length = Message::HEADER_LENGTH;
 
-        while (queue.size() > 0) {
+        while (!queue.empty()) {
             auto& ray = queue.front();
             const auto size = ray->SerializedSize();
+
+            if (size == 0) {
+                throw runtime_error("ray is not serialized");
+            }
 
             if (size + packet.length > UDP_MTU_BYTES) break;
 

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -209,11 +209,11 @@ void LambdaWorker::initBenchmark(const uint32_t duration,
                                  const uint32_t rate) {
     /* (1) disable all unnecessary actions */
     set<uint64_t> toDeactivate{
-        eventAction[Event::RayQueue],       eventAction[Event::OutQueue],
-        eventAction[Event::FinishedQueue],  eventAction[Event::Peers],
-        eventAction[Event::NeededTreelets], eventAction[Event::UdpSend],
-        eventAction[Event::UdpReceive],     eventAction[Event::RayAcks],
-        eventAction[Event::Diagnostics],    eventAction[Event::WorkerStats]};
+        eventAction[Event::RayQueue],   eventAction[Event::FinishedQueue],
+        eventAction[Event::Peers],      eventAction[Event::NeededTreelets],
+        eventAction[Event::UdpSend],    eventAction[Event::UdpReceive],
+        eventAction[Event::RayAcks],    eventAction[Event::Diagnostics],
+        eventAction[Event::WorkerStats]};
 
     loop.poller().deactivate_actions(toDeactivate);
     udpConnection.reset_reference();

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -791,8 +791,8 @@ ResultType LambdaWorker::handleUdpSend() {
     /* peer to send the packet to */
     udpConnection.bytes_sent += packet.length;
     udpConnection.record_send(packet.length);
-    udpConnection.socket().sendmsg(packet.destination, packet.iov,
-                                   packet.iovCount);
+    udpConnection.socket().sendmsg(packet.destination, packet.iov(),
+                                   packet.iovCount());
 
     /* do the necessary logging */
     if (packet.retransmission) {

--- a/src/cloud/lambda-worker.cpp
+++ b/src/cloud/lambda-worker.cpp
@@ -1065,8 +1065,8 @@ RayStatePtr LambdaWorker::popRayQueue() {
 }
 
 bool LambdaWorker::processMessage(const Message& message) {
-    cerr << "[msg:" << Message::OPCODE_NAMES[to_underlying(message.opcode())]
-         << "]" << endl;
+    /* cerr << "[msg:" << Message::OPCODE_NAMES[to_underlying(message.opcode())]
+         << "]" << endl; */
 
     auto handleConnectTo = [this](const protobuf::ConnectTo& proto) {
         if (peers.count(proto.worker_id()) == 0 &&

--- a/src/cloud/lambda-worker.h
+++ b/src/cloud/lambda-worker.h
@@ -112,7 +112,7 @@ class LambdaWorker {
         char header[meow::Message::HEADER_LENGTH];
         std::deque<std::unique_ptr<RayState>> rays;
 
-        struct iovec iov[10] = {{.iov_base = header, .iov_len = 25}};
+        struct iovec iov[20] = {{.iov_base = header, .iov_len = 25}};
         size_t iovCount{1};
 
         RayPacket(const Address& addr, const WorkerId destId,
@@ -185,7 +185,6 @@ class LambdaWorker {
     void loadFakeScene();
 
     Poller::Action::Result::Type handleRayQueue();
-    Poller::Action::Result::Type handleOutQueue();
     Poller::Action::Result::Type handleFinishedQueue();
     Poller::Action::Result::Type handleFinishedPaths();
     Poller::Action::Result::Type handlePeers();

--- a/src/cloud/lambda-worker.h
+++ b/src/cloud/lambda-worker.h
@@ -31,7 +31,6 @@ namespace pbrt {
 
 constexpr std::chrono::milliseconds PEER_CHECK_INTERVAL{250};
 constexpr std::chrono::milliseconds HANDLE_ACKS_INTERVAL{50};
-constexpr std::chrono::milliseconds OUT_QUEUE_INTERVAL{100};
 constexpr std::chrono::milliseconds WORKER_STATS_INTERVAL{1'000};
 constexpr std::chrono::milliseconds WORKER_DIAGNOSTICS_INTERVAL{2'000};
 constexpr std::chrono::milliseconds KEEP_ALIVE_INTERVAL{40'000};
@@ -170,7 +169,6 @@ class LambdaWorker {
 
     enum class Event {
         RayQueue,
-        OutQueue,
         FinishedQueue,
         FinishedPaths,
         Peers,
@@ -309,7 +307,6 @@ class LambdaWorker {
     TimerFD peerTimer{PEER_CHECK_INTERVAL};
     TimerFD workerStatsTimer{WORKER_STATS_INTERVAL};
     TimerFD workerDiagnosticsTimer{WORKER_DIAGNOSTICS_INTERVAL};
-    TimerFD outQueueTimer{OUT_QUEUE_INTERVAL};
     TimerFD finishedPathsTimer{FINISHED_PATHS_INTERVAL};
     TimerFD handleRayAcknowledgementsTimer{HANDLE_ACKS_INTERVAL};
 

--- a/src/cloud/manager.cpp
+++ b/src/cloud/manager.cpp
@@ -11,8 +11,8 @@ using namespace std;
 namespace pbrt {
 
 static const string TYPE_PREFIXES[] = {
-    "T",   "TM",   "LIGHTS", "SAMPLER",  "CAMERA", "SCENE",
-    "MAT", "FTEX", "STEX",   "MANIFEST", "TEX",    "TINFO"};
+    "T",    "TM",   "LIGHTS",   "SAMPLER", "CAMERA", "SCENE", "MAT",
+    "FTEX", "STEX", "MANIFEST", "TEX",     "TINFO",  "STATIC"};
 
 static_assert(
     sizeof(TYPE_PREFIXES) / sizeof(string) == to_underlying(ObjectType::COUNT),
@@ -60,6 +60,7 @@ string SceneManager::getFileName(const ObjectType type, const uint32_t id) {
     case ObjectType::FloatTexture:
     case ObjectType::SpectrumTexture:
     case ObjectType::Texture:
+    case ObjectType::StaticAssignment:
         return TYPE_PREFIXES[to_underlying(type)] + to_string(id);
 
     case ObjectType::Sampler:

--- a/src/cloud/manager.h
+++ b/src/cloud/manager.h
@@ -26,6 +26,7 @@ enum class ObjectType {
     Manifest,
     Texture,
     TreeletInfo,
+    StaticAssignment,
     COUNT
 };
 

--- a/src/cloud/raystate.cpp
+++ b/src/cloud/raystate.cpp
@@ -64,6 +64,29 @@ string RayState::serialize(const RayStatePtr &rayState, const bool compress) {
     return result;
 }
 
+size_t RayState::serialize_into_str(std::string &result,
+                                    const RayStatePtr &rayState,
+                                    const size_t loc, const size_t bytes_left,
+                                    const bool compress) {
+    const uint32_t size = rayState->Size();
+    if (size > bytes_left - 4) {
+        return 0;
+    }
+
+    if (compress) {
+        const uint32_t compressedSize = LZ4_compress_default(
+            (const char *)rayState.get(), (char *)&result[loc + 4], size, size);
+        memcpy(&result[loc], &compressedSize, 4);
+        ;
+
+        return compressedSize;
+    } else {
+        memcpy(&result[loc + 4], rayState.get(), size);
+        memcpy(&result[loc], &size, 4);
+        return size;
+    }
+}
+
 RayStatePtr RayState::deserialize(const string &data, const bool decompress) {
     RayStatePtr result = make_unique<RayState>();
 

--- a/src/cloud/raystate.cpp
+++ b/src/cloud/raystate.cpp
@@ -56,7 +56,6 @@ size_t RayState::Serialize(const bool compress) {
             throw runtime_error("ray compression failed");
         }
     } else {
-        len = size;
         memcpy(serialized + 4, reinterpret_cast<char *>(this), size);
     }
 

--- a/src/cloud/raystate.cpp
+++ b/src/cloud/raystate.cpp
@@ -40,67 +40,41 @@ size_t RayState::Size() const {
            sizeof(RayState::TreeletNode) * toVisitHead;
 }
 
-string RayState::serialize(const RayStatePtr &rayState, const bool compress) {
-    const size_t size = rayState->Size();
+/*******************************************************************************
+ * SERIALIZATION                                                               *
+ ******************************************************************************/
 
-    string result;
-    result.resize(size);
-    memcpy(&result[0], rayState.get(), size);
+size_t RayState::Serialize(const bool compress) {
+    const size_t size = this->Size();
+    uint32_t len = size;
 
     if (compress) {
-        string compressed;
-        compressed.resize(size);
-        const auto compressedSize =
-            LZ4_compress_default(result.data(), &compressed[0], size, size);
+        len = LZ4_compress_default(reinterpret_cast<char *>(this),
+                                   serialized + 4, size, size);
 
-        if (compressedSize == 0) {
+        if (len == 0) {
             throw runtime_error("ray compression failed");
         }
-
-        compressed.resize(compressedSize);
-        result.swap(compressed);
-    }
-
-    return result;
-}
-
-size_t RayState::serialize_into_str(std::string &result,
-                                    const RayStatePtr &rayState,
-                                    const size_t loc, const size_t bytes_left,
-                                    const bool compress) {
-    const uint32_t size = rayState->Size();
-    if (size > bytes_left - 4) {
-        return 0;
-    }
-
-    if (compress) {
-        const uint32_t compressedSize = LZ4_compress_default(
-            (const char *)rayState.get(), (char *)&result[loc + 4], size, size);
-        memcpy(&result[loc], &compressedSize, 4);
-        ;
-
-        return compressedSize;
     } else {
-        memcpy(&result[loc + 4], rayState.get(), size);
-        memcpy(&result[loc], &size, 4);
-        return size;
+        len = size;
+        memcpy(serialized + 4, reinterpret_cast<char *>(this), size);
     }
+
+    memcpy(serialized, &len, 4);
+    serializedSize = len + 4;
+
+    return serializedSize;
 }
 
-RayStatePtr RayState::deserialize(const string &data, const bool decompress) {
-    RayStatePtr result = make_unique<RayState>();
-
+void RayState::Deserialize(const char *data, const size_t len,
+                           const bool decompress) {
     if (decompress) {
-        const auto decompressedSize = LZ4_decompress_safe(
-            data.data(), reinterpret_cast<char *>(result.get()), data.length(),
-            sizeof(RayState));
-
-        if (decompressedSize < 0) {
+        if (LZ4_decompress_safe(data, reinterpret_cast<char *>(this), len,
+                                sizeof(RayState)) < 0) {
             throw runtime_error("ray decompression failed");
         }
     } else {
-        memcpy(result.get(), data.data(), min(sizeof(RayState), data.length()));
+        memcpy(reinterpret_cast<char *>(this), data,
+               min(sizeof(RayState), len));
     }
-
-    return move(result);
 }

--- a/src/cloud/raystate.h
+++ b/src/cloud/raystate.h
@@ -73,6 +73,9 @@ struct RayState {
     size_t Size() const;
     static std::string serialize(const RayStatePtr &, const bool = true);
     static RayStatePtr deserialize(const std::string &, const bool = true);
+    static size_t serialize_into_str(std::string &, const RayStatePtr &,
+                                     const size_t, const size_t,
+                                     const bool = true);
 };
 
 }  // namespace pbrt

--- a/src/cloud/raystate.h
+++ b/src/cloud/raystate.h
@@ -58,6 +58,12 @@ struct RayState {
     uint8_t toVisitHead{0};
     TreeletNode toVisit[64];
 
+    /* RayState is serialized up until this point, and the serialized data
+       will be stored below */
+
+    size_t serializedSize{0};
+    char serialized[1400];
+
     bool toVisitEmpty() const { return toVisitHead == 0; }
     const TreeletNode &toVisitTop() const { return toVisit[toVisitHead - 1]; }
     void toVisitPush(TreeletNode &&t) { toVisit[toVisitHead++] = std::move(t); }
@@ -71,11 +77,10 @@ struct RayState {
 
     /* serialization */
     size_t Size() const;
-    static std::string serialize(const RayStatePtr &, const bool = true);
-    static RayStatePtr deserialize(const std::string &, const bool = true);
-    static size_t serialize_into_str(std::string &, const RayStatePtr &,
-                                     const size_t, const size_t,
-                                     const bool = true);
+    size_t SerializedSize() const { return serializedSize; }
+    size_t Serialize(const bool compress = true);
+    void Deserialize(const char *data, const size_t len,
+                     const bool decompress = true);
 };
 
 }  // namespace pbrt

--- a/src/cloud/raystate.h
+++ b/src/cloud/raystate.h
@@ -16,7 +16,7 @@ struct RayState;
 using RayStatePtr = std::unique_ptr<RayState>;
 
 struct RayState {
-    struct TreeletNode {
+    struct __attribute__((packed)) TreeletNode {
         uint32_t treelet{0};
         uint32_t node{0};
         uint8_t primitive{0};

--- a/src/cloud/treelet-info.cpp
+++ b/src/cloud/treelet-info.cpp
@@ -1,0 +1,117 @@
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "cloud/bvh.h"
+#include "cloud/manager.h"
+#include "util/exception.h"
+#include "util/path.h"
+
+using namespace std;
+using namespace pbrt;
+
+void usage(const char *argv0) { cerr << argv0 << " OP SCENE-PATH NUM" << endl; }
+
+void generateReport(const roost::path &scenePath,
+                    const map<uint32_t, CloudBVH::TreeletInfo> &treeletInfo) {
+    auto filename = [](const uint32_t tId) { return "T" + to_string(tId); };
+
+    map<uint32_t, size_t> treeletSizes;
+
+    for (const auto &item : treeletInfo) {
+        const auto id = item.first;
+        const auto &info = item.second;
+
+        treeletSizes[id] = roost::file_size(scenePath / filename(id));
+    }
+
+    for (const auto &item : treeletInfo) {
+        const auto id = item.first;
+        const auto &info = item.second;
+
+        for (const auto t : info.instances) {
+            treeletSizes[id] += treeletSizes[t];
+        }
+    }
+
+    queue<uint32_t> toVisit;
+    toVisit.push(0);
+
+    while (!toVisit.empty()) {
+        const auto c = toVisit.front();
+        toVisit.pop();
+
+        cout << "T" << c << " = " << fixed << setprecision(2)
+             << (1.0 * treeletSizes[c] / (1 << 20)) << " MiB" << endl;
+
+        for (const auto t : treeletInfo.at(c).children) {
+            toVisit.push(t);
+        }
+    }
+}
+
+void generateGraph(const map<uint32_t, CloudBVH::TreeletInfo> &treeletInfo) {
+    cout << "digraph bvh {" << endl;
+
+    for (const auto &item : treeletInfo) {
+        const auto id = item.first;
+        const auto &info = item.second;
+
+        for (const auto t : info.children) {
+            cout << "  "
+                 << "T" << id << " -> T" << t << endl;
+        }
+
+        for (const auto t : info.instances) {
+            cout << "  "
+                 << "T" << id << " -> T" << t << " [style=dotted]" << endl;
+        }
+    }
+
+    cout << "}" << endl;
+}
+
+int main(int argc, char const *argv[]) {
+    try {
+        if (argc <= 0) {
+            abort();
+        }
+
+        if (argc != 4) {
+            usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+
+        FLAGS_logtostderr = false;
+        FLAGS_minloglevel = 3;
+        PbrtOptions.nThreads = 1;
+
+        const string operation{argv[1]};
+        const string scenePath{argv[2]};
+        const uint32_t treeletCount = stoul(argv[3]);
+        global::manager.init(scenePath);
+
+        map<uint32_t, CloudBVH::TreeletInfo> treeletInfo;
+
+        for (size_t i = 0; i < treeletCount; i++) {
+            CloudBVH bvh{};
+            treeletInfo[i] = bvh.GetInfo(i);
+        }
+
+        if (operation == "report") {
+            generateReport(scenePath, treeletInfo);
+        } else if (operation == "graph") {
+            generateGraph(treeletInfo);
+        }
+
+    } catch (const exception &e) {
+        print_exception(argv[0], e);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/execution/loop.cpp
+++ b/src/execution/loop.cpp
@@ -411,6 +411,7 @@ Poller::Action::Result ExecutionLoop::handle_signal(
         throw runtime_error("interrupted by signal");
 
     case SIGINT:
+        cerr << endl;
         return ResultType::Exit;
 
     default:

--- a/src/execution/meow/message.cpp
+++ b/src/execution/meow/message.cpp
@@ -48,7 +48,7 @@ string Message::str() const {
                         sequence_number_, tracked_);
 }
 
-void Message::str(std::string& message_str, const uint64_t sender_id,
+void Message::str(char* message_str, const uint64_t sender_id,
                   const OpCode opcode, const size_t payloadLength,
                   const bool reliable, const uint64_t sequence_number,
                   const bool tracked) {

--- a/src/execution/meow/message.cpp
+++ b/src/execution/meow/message.cpp
@@ -16,7 +16,7 @@ constexpr char const*
     Message::OPCODE_NAMES[to_underlying(Message::OpCode::COUNT)];
 
 Message::Message(const Chunk& chunk) {
-    if (chunk.size() < 25) {
+    if (chunk.size() < HEADER_LENGTH) {
         throw out_of_range("incomplete header");
     }
 
@@ -82,7 +82,8 @@ std::string Message::str(const uint64_t sender_id, const OpCode opcode,
 }
 
 uint32_t Message::expected_length(const Chunk& chunk) {
-    return 25 + ((chunk.size() < 25) ? 0 : chunk(20, 4).be32());
+    return HEADER_LENGTH +
+           ((chunk.size() < HEADER_LENGTH) ? 0 : chunk(20, 4).be32());
 }
 
 void MessageParser::parse(const string& buf) {

--- a/src/execution/meow/message.cpp
+++ b/src/execution/meow/message.cpp
@@ -2,9 +2,9 @@
 
 #include "message.h"
 
+#include <endian.h>
 #include <iostream>
 #include <stdexcept>
-#include <endian.h>
 
 #include "net/util.h"
 #include "util/util.h"
@@ -12,83 +12,94 @@
 using namespace std;
 using namespace meow;
 
-constexpr char const* Message::OPCODE_NAMES[to_underlying(Message::OpCode::COUNT)];
+constexpr char const*
+    Message::OPCODE_NAMES[to_underlying(Message::OpCode::COUNT)];
 
-Message::Message( const Chunk & chunk )
-{
-  if ( chunk.size() < 25 ) {
-    throw out_of_range( "incomplete header" );
-  }
-
-  Chunk c = chunk;
-
-  attempt_         = c.be16();
-  tracked_         = ( c = c( 2 ) ).octet();
-  reliable_        = ( c = c( 1 ) ).octet();
-  sender_id_       = ( c = c( 1 ) ).be64();
-  sequence_number_ = ( c = c( 8 ) ).be64();
-  payload_length_  = ( c = c( 8 ) ).be32();
-  opcode_          = static_cast<OpCode>( ( c = c( 4 ) ).octet() );
-  payload_         = ( c = c( 1 ) ).to_string();
-}
-
-Message::Message( const uint64_t sender_id,
-                  const OpCode opcode, string && payload,
-                  const bool reliable, const uint64_t sequence_number,
-                  const bool tracked )
-  : tracked_( tracked ), reliable_( reliable ), sender_id_( sender_id ),
-    sequence_number_( sequence_number ),
-    payload_length_( payload.length() ), opcode_( opcode ),
-    payload_( move( payload ) )
-{}
-
-string Message::str() const
-{
-  return Message::str( sender_id_, opcode_, payload_, reliable_,
-                       sequence_number_, tracked_ );
-}
-
-std::string Message::str( const uint64_t sender_id,
-                          const OpCode opcode,
-                          const string & payload,
-                          const bool reliable,
-                          const uint64_t sequence_number,
-                          const bool tracked ) {
-  string output;
-  output.reserve( sizeof(uint16_t) + sizeof(tracked) + sizeof(reliable) + sizeof(sender_id) +
-                  sizeof(sequence_number) + sizeof(opcode) +
-                  sizeof(payload.length()) + payload.length() );
-
-  output += put_field( static_cast<uint16_t>( 0 ) );
-  output += put_field( tracked );
-  output += put_field( reliable );
-  output += put_field( sender_id );
-  output += put_field( sequence_number );
-  output += put_field( static_cast<uint32_t>( payload.length() ) );
-  output += to_underlying( opcode );
-  output += payload;
-  return output;
-}
-
-uint32_t Message::expected_length( const Chunk & chunk )
-{
-  return 25 + ( ( chunk.size() < 25 ) ? 0 : chunk( 20, 4 ).be32() );
-}
-
-void MessageParser::parse( const string & buf )
-{
-  raw_buffer_.append( buf );
-
-  while ( true ) {
-    uint32_t expected_length = Message::expected_length( raw_buffer_ );
-
-    if ( raw_buffer_.length() < expected_length ) {
-      /* still need more bytes to have a complete message */
-      break;
+Message::Message(const Chunk& chunk) {
+    if (chunk.size() < 25) {
+        throw out_of_range("incomplete header");
     }
 
-    Message message { Chunk { reinterpret_cast<const uint8_t *>( raw_buffer_.data() ), expected_length } };
-    raw_buffer_.erase( 0, expected_length );
-    completed_messages_.push_back( move( message ) );
-  }
+    Chunk c = chunk;
+
+    attempt_ = c.be16();
+    tracked_ = (c = c(2)).octet();
+    reliable_ = (c = c(1)).octet();
+    sender_id_ = (c = c(1)).be64();
+    sequence_number_ = (c = c(8)).be64();
+    payload_length_ = (c = c(8)).be32();
+    opcode_ = static_cast<OpCode>((c = c(4)).octet());
+    payload_ = (c = c(1)).to_string();
+}
+
+Message::Message(const uint64_t sender_id, const OpCode opcode,
+                 string&& payload, const bool reliable,
+                 const uint64_t sequence_number, const bool tracked)
+    : tracked_(tracked),
+      reliable_(reliable),
+      sender_id_(sender_id),
+      sequence_number_(sequence_number),
+      payload_length_(payload.length()),
+      opcode_(opcode),
+      payload_(move(payload)) {}
+
+string Message::str() const {
+    return Message::str(sender_id_, opcode_, payload_, reliable_,
+                        sequence_number_, tracked_);
+}
+
+void Message::str(std::string& message_str, const uint64_t sender_id,
+                  const OpCode opcode, const size_t payloadLength,
+                  const bool reliable, const uint64_t sequence_number,
+                  const bool tracked) {
+    put_field(message_str, static_cast<uint16_t>(0), 0);
+    put_field(message_str, tracked, 2);
+    put_field(message_str, reliable, 3);
+    put_field(message_str, sender_id, 4);
+    put_field(message_str, sequence_number, 12);
+    put_field(message_str, static_cast<uint32_t>(payloadLength), 20);
+    message_str[24] = to_underlying(opcode);
+}
+
+std::string Message::str(const uint64_t sender_id, const OpCode opcode,
+                         const string& payload, const bool reliable,
+                         const uint64_t sequence_number, const bool tracked) {
+    string output;
+    output.reserve(sizeof(uint16_t) + sizeof(tracked) + sizeof(reliable) +
+                   sizeof(sender_id) + sizeof(sequence_number) +
+                   sizeof(opcode) + sizeof(payload.length()) +
+                   payload.length());
+
+    output += put_field(static_cast<uint16_t>(0));
+    output += put_field(tracked);
+    output += put_field(reliable);
+    output += put_field(sender_id);
+    output += put_field(sequence_number);
+    output += put_field(static_cast<uint32_t>(payload.length()));
+    output += to_underlying(opcode);
+    output += payload;
+    return output;
+}
+
+uint32_t Message::expected_length(const Chunk& chunk) {
+    return 25 + ((chunk.size() < 25) ? 0 : chunk(20, 4).be32());
+}
+
+void MessageParser::parse(const string& buf) {
+    raw_buffer_.append(buf);
+
+    while (true) {
+        uint32_t expected_length = Message::expected_length(raw_buffer_);
+
+        if (raw_buffer_.length() < expected_length) {
+            /* still need more bytes to have a complete message */
+            break;
+        }
+
+        Message message{
+            Chunk{reinterpret_cast<const uint8_t*>(raw_buffer_.data()),
+                  expected_length}};
+        raw_buffer_.erase(0, expected_length);
+        completed_messages_.push_back(move(message));
+    }
 }

--- a/src/execution/meow/message.h
+++ b/src/execution/meow/message.h
@@ -3,38 +3,36 @@
 #ifndef PBRT_EXECUTION_MEOW_MESSAGE_H
 #define PBRT_EXECUTION_MEOW_MESSAGE_H
 
-#include <string>
 #include <list>
+#include <string>
 
 #include "util/chunk.h"
 #include "util/util.h"
 
 namespace meow {
 
-  class Message
-  {
+class Message {
   public:
-    enum class OpCode: uint8_t
-    {
-      Hey = 0x1,
-      Ping,
-      Pong,
-      Ack,
-      GetObjects,
-      GenerateRays,
-      GetWorker,
-      ConnectTo,
-      MultipleConnect,
-      ConnectionRequest,
-      ConnectionResponse,
-      WorkerStats,
-      SendRays,
-      FinishedRays,
-      FinishedPaths,
-      StartBenchmark,
-      Bye,
+    enum class OpCode : uint8_t {
+        Hey = 0x1,
+        Ping,
+        Pong,
+        Ack,
+        GetObjects,
+        GenerateRays,
+        GetWorker,
+        ConnectTo,
+        MultipleConnect,
+        ConnectionRequest,
+        ConnectionResponse,
+        WorkerStats,
+        SendRays,
+        FinishedRays,
+        FinishedPaths,
+        StartBenchmark,
+        Bye,
 
-      COUNT
+        COUNT
     };
 
     static constexpr char const* OPCODE_NAMES[to_underlying(OpCode::COUNT)] = {
@@ -58,25 +56,22 @@ namespace meow {
         "Bye"};
 
   private:
-    uint16_t attempt_ { 0 };
-    bool tracked_ { false };
-    bool reliable_ { false };
-    uint64_t sender_id_ { 0 };
-    uint64_t sequence_number_ { 0 };
-    uint32_t payload_length_ { 0 };
-    OpCode opcode_ { OpCode::Hey };
-    std::string payload_ {};
+    uint16_t attempt_{0};
+    bool tracked_{false};
+    bool reliable_{false};
+    uint64_t sender_id_{0};
+    uint64_t sequence_number_{0};
+    uint32_t payload_length_{0};
+    OpCode opcode_{OpCode::Hey};
+    std::string payload_{};
 
-    bool read_ { false };
+    bool read_{false};
 
   public:
-    Message( const Chunk & chunk );
-    Message( const uint64_t sender_id,
-             const OpCode opcode,
-             std::string && payload,
-             const bool reliable = false,
-             const uint64_t sequence_number = 0,
-             const bool tracked = false );
+    Message(const Chunk& chunk);
+    Message(const uint64_t sender_id, const OpCode opcode,
+            std::string&& payload, const bool reliable = false,
+            const uint64_t sequence_number = 0, const bool tracked = false);
 
     uint16_t attempt() const { return attempt_; }
     uint64_t sender_id() const { return sender_id_; }
@@ -85,43 +80,47 @@ namespace meow {
     uint64_t sequence_number() const { return sequence_number_; }
     OpCode opcode() const { return opcode_; }
     uint32_t payload_length() const { return payload_length_; }
-    const std::string & payload() const { return payload_; }
+    const std::string& payload() const { return payload_; }
 
     size_t total_length() const { return 25 + payload_length(); }
 
     std::string str() const;
 
-    static std::string str( const uint64_t sender_id,
-                            const OpCode opcode,
-                            const std::string & payload,
-                            const bool reliable = false,
-                            const uint64_t sequence_number = 0,
-                            const bool tracked = false );
+    static void str(std::string& message_str, const uint64_t sender_id,
+                    const OpCode opcode, const size_t payloadLength,
+                    const bool reliable = false,
+                    const uint64_t sequence_number = 0,
+                    const bool tracked = false);
 
-    static uint32_t expected_length( const Chunk & chunk );
+    static std::string str(const uint64_t sender_id, const OpCode opcode,
+                           const std::string& payload,
+                           const bool reliable = false,
+                           const uint64_t sequence_number = 0,
+                           const bool tracked = false);
+
+    static uint32_t expected_length(const Chunk& chunk);
 
     bool is_read() const { return read_; }
     void set_read() { read_ = true; }
-  };
+};
 
-  class MessageParser
-  {
+class MessageParser {
   private:
-    std::string raw_buffer_ {};
-    std::list<Message> completed_messages_ {};
+    std::string raw_buffer_{};
+    std::list<Message> completed_messages_{};
 
   public:
-    void parse( const std::string & buf );
+    void parse(const std::string& buf);
 
     bool empty() const { return completed_messages_.empty(); }
-    Message & front() { return completed_messages_.front(); }
+    Message& front() { return completed_messages_.front(); }
     void pop() { completed_messages_.pop_front(); }
-    void push( Message && msg ) { completed_messages_.push_back( std::move( msg ) ); }
+    void push(Message&& msg) { completed_messages_.push_back(std::move(msg)); }
     size_t size() const { return completed_messages_.size(); }
 
-    std::list<Message> & completed_messages() { return completed_messages_; }
-  };
+    std::list<Message>& completed_messages() { return completed_messages_; }
+};
 
-}
+}  // namespace meow
 
 #endif /* PBRT_EXECUTION_MEOW_REQUEST_H */

--- a/src/execution/meow/message.h
+++ b/src/execution/meow/message.h
@@ -55,6 +55,8 @@ class Message {
         "StartBenchmark",
         "Bye"};
 
+    constexpr static size_t HEADER_LENGTH = 25;
+
   private:
     uint16_t attempt_{0};
     bool tracked_{false};
@@ -82,11 +84,11 @@ class Message {
     uint32_t payload_length() const { return payload_length_; }
     const std::string& payload() const { return payload_; }
 
-    size_t total_length() const { return 25 + payload_length(); }
+    size_t total_length() const { return HEADER_LENGTH + payload_length(); }
 
     std::string str() const;
 
-    static void str(std::string& message_str, const uint64_t sender_id,
+    static void str(char* message_str, const uint64_t sender_id,
                     const OpCode opcode, const size_t payloadLength,
                     const bool reliable = false,
                     const uint64_t sequence_number = 0,

--- a/src/messages/serialization.h
+++ b/src/messages/serialization.h
@@ -28,6 +28,7 @@ public:
     void write(const ProtobufType & proto);
 
     void write(const std::string & string);
+    void write(const char* data, const uint32_t len);
 
     void write(const uint32_t& integer);
     void write(const uint64_t& integer);
@@ -54,6 +55,7 @@ public:
     bool read(ProtobufType * record);
 
     bool read(std::string* string);
+    bool read(char* data, const uint32_t max_len);
 
     bool read(uint32_t* integer);
     bool read(uint64_t* integer);

--- a/src/net/socket.cpp
+++ b/src/net/socket.cpp
@@ -108,6 +108,23 @@ void UDPSocket::sendto( const Address & destination, const string & payload )
     }
 }
 
+void UDPSocket::sendmsg( const Address & peer, const iovec * iov,
+                         const size_t iovcnt )
+{
+    struct msghdr message_header = {
+        .msg_name = ( void * )&peer.to_sockaddr(),
+        .msg_namelen = peer.size(),
+        .msg_iov = ( struct iovec * )iov,
+        .msg_iovlen = iovcnt,
+        .msg_control = nullptr,
+        .msg_controllen = 0,
+        .msg_flags = 0
+    };
+
+    CheckSystemCall( "sendmsg", ::sendmsg( fd_num(), &message_header, 0 ) );
+    register_write();
+}
+
 /* send datagram to connected address */
 void UDPSocket::send( const string & payload )
 {

--- a/src/net/socket.h
+++ b/src/net/socket.h
@@ -4,6 +4,7 @@
 #define PBRT_NET_SOCKET_H
 
 #include <functional>
+#include <sys/uio.h>
 
 #include "address.h"
 #include "util/file_descriptor.h"
@@ -57,6 +58,10 @@ public:
 
     /* send datagram to specified address */
     void sendto( const Address & peer, const std::string & payload );
+
+    /* sendmsg */
+    void sendmsg( const Address & peer, const iovec * iov,
+                  const size_t iovcnt );
 
     /* send datagram to connected address */
     void send( const std::string & payload );

--- a/src/net/util.cpp
+++ b/src/net/util.cpp
@@ -26,28 +26,24 @@ string put_field(const uint16_t n) {
                   sizeof(network_order));
 }
 
-void put_field(string &message, const bool n, size_t loc) {
-    if (n) {
-        message[loc] = '\x01';
-    } else {
-        message[loc] = '\x00';
-    }
+void put_field(char *message, const bool n, size_t loc) {
+    message[loc] = n ? '\x01' : '\x00';
 }
 
-void put_field(string &message, const uint64_t n, size_t loc) {
+void put_field(char *message, const uint64_t n, size_t loc) {
     const uint64_t network_order = htobe64(n);
-    memcpy(&message[loc], reinterpret_cast<const char *>(&network_order),
+    memcpy(message + loc, reinterpret_cast<const char *>(&network_order),
            sizeof(network_order));
 }
 
-void put_field(string &message, const uint32_t n, size_t loc) {
+void put_field(char *message, const uint32_t n, size_t loc) {
     const uint32_t network_order = htobe32(n);
-    memcpy(&message[loc], reinterpret_cast<const char *>(&network_order),
+    memcpy(message + loc, reinterpret_cast<const char *>(&network_order),
            sizeof(network_order));
 }
 
-void put_field(string &message, const uint16_t n, size_t loc) {
+void put_field(char *message, const uint16_t n, size_t loc) {
     const uint32_t network_order = htobe16(n);
-    memcpy(&message[loc], reinterpret_cast<const char *>(&network_order),
+    memcpy(message + loc, reinterpret_cast<const char *>(&network_order),
            sizeof(network_order));
 }

--- a/src/net/util.cpp
+++ b/src/net/util.cpp
@@ -25,3 +25,29 @@ string put_field(const uint16_t n) {
     return string(reinterpret_cast<const char *>(&network_order),
                   sizeof(network_order));
 }
+
+void put_field(string &message, const bool n, size_t loc) {
+    if (n) {
+        message[loc] = '\x01';
+    } else {
+        message[loc] = '\x00';
+    }
+}
+
+void put_field(string &message, const uint64_t n, size_t loc) {
+    const uint64_t network_order = htobe64(n);
+    memcpy(&message[loc], reinterpret_cast<const char *>(&network_order),
+           sizeof(network_order));
+}
+
+void put_field(string &message, const uint32_t n, size_t loc) {
+    const uint32_t network_order = htobe32(n);
+    memcpy(&message[loc], reinterpret_cast<const char *>(&network_order),
+           sizeof(network_order));
+}
+
+void put_field(string &message, const uint16_t n, size_t loc) {
+    const uint32_t network_order = htobe16(n);
+    memcpy(&message[loc], reinterpret_cast<const char *>(&network_order),
+           sizeof(network_order));
+}

--- a/src/net/util.h
+++ b/src/net/util.h
@@ -9,16 +9,16 @@ std::string put_field(const uint64_t n);
 std::string put_field(const uint32_t n);
 std::string put_field(const uint16_t n);
 
-void put_field(std::string& message, const bool n, size_t loc);
-void put_field(std::string& message, const uint64_t n, size_t loc);
-void put_field(std::string& message, const uint32_t n, size_t loc);
-void put_field(std::string& message, const uint16_t n, size_t loc);
+void put_field(char* message, const bool n, size_t loc);
+void put_field(char* message, const uint64_t n, size_t loc);
+void put_field(char* message, const uint32_t n, size_t loc);
+void put_field(char* message, const uint16_t n, size_t loc);
 
 /* avoid implicit conversions */
 template <class T>
 std::string put_field(T n) = delete;
 
 template <class T>
-std::string put_field(std::string& message, T n, size_t) = delete;
+std::string put_field(char* message, T n, size_t) = delete;
 
 #endif /* PBRT_NET_UTIL_H */

--- a/src/net/util.h
+++ b/src/net/util.h
@@ -1,6 +1,7 @@
 #ifndef PBRT_NET_UTIL_H
 #define PBRT_NET_UTIL_H
 
+#include <cstring>
 #include <string>
 
 std::string put_field(const bool n);
@@ -8,8 +9,16 @@ std::string put_field(const uint64_t n);
 std::string put_field(const uint32_t n);
 std::string put_field(const uint16_t n);
 
+void put_field(std::string& message, const bool n, size_t loc);
+void put_field(std::string& message, const uint64_t n, size_t loc);
+void put_field(std::string& message, const uint32_t n, size_t loc);
+void put_field(std::string& message, const uint16_t n, size_t loc);
+
 /* avoid implicit conversions */
 template <class T>
 std::string put_field(T n) = delete;
+
+template <class T>
+std::string put_field(std::string& message, T n, size_t) = delete;
 
 #endif /* PBRT_NET_UTIL_H */


### PR DESCRIPTION
Reduce string allocations by preallocating string space when sending ray packet messages.